### PR TITLE
feat: per-user aoe workspaces with orchestrator seam, docker backend, and gated proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,8 @@ dependencies = [
  "chrono",
  "clap",
  "getrandom 0.3.4",
+ "hyper",
+ "hyper-util",
  "lettre",
  "openidconnect",
  "rand 0.10.2",
@@ -971,6 +973,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1129,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1159,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2493,6 +2517,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2512,12 +2537,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.8",
 ]
@@ -3051,6 +3078,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3522,6 +3559,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -3941,6 +3979,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,17 +21,21 @@ base64 = "0.22.1"
 chrono = { version = "0.4.45", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
 getrandom = "0.3"
+# Direct hyper/hyper-util deps only for the workspace proxy's WebSocket
+# upgrade tunneling (axum already pulls both transitively).
+hyper = { version = "1", features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "pool", "tokio1", "tokio1-rustls-tls", "hostname"] }
 openidconnect = { version = "4.0.1", default-features = false, features = ["reqwest"] }
 rand = "0.10.2"
 # Pins reqwest (pulled transitively by openidconnect via oauth2) to rustls so
 # the build stays OpenSSL-free like the rest of the stack.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
 sea-orm = { version = "1.1.20", features = ["sqlx-sqlite", "sqlx-postgres", "sqlx-mysql", "runtime-tokio-rustls", "macros", "with-chrono"] }
 sea-orm-migration = { version = "1.1.20", features = ["runtime-tokio-rustls", "sqlx-sqlite", "sqlx-postgres", "sqlx-mysql"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "time"] }
 tower = "0.5.3"
 tower-http = { version = "0.7.0", features = ["fs", "trace"] }
 tracing = "0.1"

--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -2,7 +2,7 @@ use argon2::password_hash::{
     rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString,
 };
 use argon2::Argon2;
-use axum::extract::FromRequestParts;
+use axum::extract::{FromRef, FromRequestParts};
 use axum::http::request::Parts;
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use chrono::{Duration, Utc};
@@ -165,13 +165,18 @@ impl AuthUser {
     }
 }
 
-impl FromRequestParts<DatabaseConnection> for AuthUser {
+// Generic over the state so the same extractor serves the main router (state
+// is `AppState`) and DB-only contexts; anything holding a `DatabaseConnection`
+// via `FromRef` works.
+impl<S> FromRequestParts<S> for AuthUser
+where
+    DatabaseConnection: FromRef<S>,
+    S: Send + Sync,
+{
     type Rejection = AppError;
 
-    async fn from_request_parts(
-        parts: &mut Parts,
-        db: &DatabaseConnection,
-    ) -> Result<Self, Self::Rejection> {
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let db = &DatabaseConnection::from_ref(state);
         let jar = CookieJar::from_headers(&parts.headers);
         let token = jar
             .get(SESSION_COOKIE)

--- a/api/src/entities/mod.rs
+++ b/api/src/entities/mod.rs
@@ -5,3 +5,5 @@ pub mod role;
 pub mod session;
 pub mod smtp_settings;
 pub mod user;
+pub mod workspace;
+pub mod workspace_settings;

--- a/api/src/entities/workspace.rs
+++ b/api/src/entities/workspace.rs
@@ -1,0 +1,36 @@
+use sea_orm::entity::prelude::*;
+
+/// A user's workspace: intent only (pinned version, activity checkpoint).
+/// Runtime state (running/stopped, address) always comes from the
+/// orchestrator; the row exists as soon as the user first uses a workspace.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "workspaces")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub user_id: i32,
+    /// Pinned aoe version; `None` follows the default from workspace settings.
+    pub pinned_version: Option<String>,
+    /// Coarse activity checkpoint (the live value is in-memory).
+    pub last_active_at: Option<DateTimeUtc>,
+    pub created_at: DateTimeUtc,
+    pub updated_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::UserId",
+        to = "super::user::Column::Id",
+        on_delete = "Cascade"
+    )]
+    User,
+}
+
+impl Related<super::user::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/api/src/entities/workspace_settings.rs
+++ b/api/src/entities/workspace_settings.rs
@@ -7,7 +7,6 @@ use sea_orm::entity::prelude::*;
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: i32,
-    pub enabled: bool,
     /// Image reference with a `{version}` placeholder, e.g.
     /// `cityhall/aoe:{version}`.
     pub image_template: String,

--- a/api/src/entities/workspace_settings.rs
+++ b/api/src/entities/workspace_settings.rs
@@ -1,0 +1,24 @@
+use sea_orm::entity::prelude::*;
+
+/// Single-row workspace orchestration configuration (the row always has
+/// `id = 1`).
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "workspace_settings")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: i32,
+    pub enabled: bool,
+    /// Image reference with a `{version}` placeholder, e.g.
+    /// `cityhall/aoe:{version}`.
+    pub image_template: String,
+    /// Version served to users without a pin; workspaces cannot start while
+    /// unset.
+    pub default_version: Option<String>,
+    pub idle_stop_minutes: i32,
+    pub updated_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -11,6 +11,9 @@ pub enum AppError {
     Conflict(&'static str),
     BadRequest(&'static str),
     Internal(&'static str),
+    /// A workspace could not be reached or materialized; the message carries
+    /// operator guidance (image missing, runtime down...).
+    WorkspaceUnavailable(String),
     Db(sea_orm::DbErr),
 }
 
@@ -28,6 +31,7 @@ impl std::fmt::Display for AppError {
                 write!(f, "{m}")
             }
             AppError::BadRequest(m) | AppError::Internal(m) => write!(f, "{m}"),
+            AppError::WorkspaceUnavailable(m) => write!(f, "{m}"),
             AppError::Db(e) => write!(f, "{e}"),
         }
     }
@@ -46,6 +50,10 @@ impl IntoResponse for AppError {
             AppError::Internal(m) => {
                 tracing::error!("internal error: {m}");
                 (StatusCode::INTERNAL_SERVER_ERROR, m.to_string())
+            }
+            AppError::WorkspaceUnavailable(m) => {
+                tracing::warn!("workspace unavailable: {m}");
+                (StatusCode::SERVICE_UNAVAILABLE, m)
             }
             AppError::Db(e) => {
                 tracing::error!("database error: {e}");

--- a/api/src/handlers/mod.rs
+++ b/api/src/handlers/mod.rs
@@ -4,3 +4,4 @@ pub mod roles;
 pub mod settings;
 pub mod signup;
 pub mod users;
+pub mod workspaces;

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -1,0 +1,274 @@
+use axum::extract::{Path, State};
+use axum::http::HeaderMap;
+use axum::Json;
+use chrono::Utc;
+use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+use serde::{Deserialize, Serialize};
+
+use crate::auth::AuthUser;
+use crate::entities::{workspace, workspace_settings};
+use crate::error::AppError;
+use crate::orchestrator::WorkspaceStatus;
+use crate::proxy;
+use crate::state::AppState;
+use crate::workspaces::{self, SETTINGS_ID};
+
+#[derive(Serialize)]
+pub struct WorkspaceItem {
+    pub user_id: i32,
+    pub username: String,
+    /// `not_created` | `stopped` | `running` | `unknown` (runtime unreachable).
+    pub status: &'static str,
+    pub pinned_version: Option<String>,
+    pub effective_version: Option<String>,
+    pub last_active_at: Option<chrono::DateTime<Utc>>,
+}
+
+fn status_str(status: Result<WorkspaceStatus, impl std::fmt::Display>) -> &'static str {
+    match status {
+        Ok(WorkspaceStatus::NotCreated) => "not_created",
+        Ok(WorkspaceStatus::Stopped) => "stopped",
+        Ok(WorkspaceStatus::Running { .. }) => "running",
+        Err(e) => {
+            tracing::warn!("workspace status check failed: {e}");
+            "unknown"
+        }
+    }
+}
+
+/// GET /api/workspaces: every user with their workspace state.
+pub async fn list(
+    State(state): State<AppState>,
+    caller: AuthUser,
+) -> Result<Json<Vec<WorkspaceItem>>, AppError> {
+    caller.require("workspaces.read")?;
+    let cfg = workspaces::settings(&state.db).await?;
+    let users = crate::service::list(&state.db).await?;
+    let rows = workspace::Entity::find().all(&state.db).await?;
+
+    let mut items = Vec::with_capacity(users.len());
+    for user in users {
+        let row = rows.iter().find(|r| r.user_id == user.id);
+        let effective = row.and_then(|r| workspaces::effective_version(&cfg, r));
+        items.push(WorkspaceItem {
+            user_id: user.id,
+            status: match row {
+                Some(_) => status_str(state.orchestrator.status(user.id).await),
+                // No intent row: never used, skip the runtime round-trip.
+                None => "not_created",
+            },
+            pinned_version: row.and_then(|r| r.pinned_version.clone()),
+            effective_version: effective.or_else(|| cfg.default_version.clone()),
+            last_active_at: row.and_then(|r| r.last_active_at),
+            username: user.username,
+        });
+    }
+    Ok(Json(items))
+}
+
+/// GET /api/workspaces/me: the caller's own workspace.
+pub async fn me(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    caller: AuthUser,
+) -> Result<Json<serde_json::Value>, AppError> {
+    caller.require("workspaces.use")?;
+    let cfg = workspaces::settings(&state.db).await?;
+    let row = workspace::Entity::find_by_id(caller.user.id)
+        .one(&state.db)
+        .await?;
+    let status = status_str(state.orchestrator.status(caller.user.id).await);
+    let effective = row
+        .as_ref()
+        .and_then(|r| workspaces::effective_version(&cfg, r))
+        .or_else(|| cfg.default_version.clone());
+    Ok(Json(serde_json::json!({
+        "enabled": cfg.enabled,
+        "status": status,
+        "pinned_version": row.as_ref().and_then(|r| r.pinned_version.clone()),
+        "effective_version": effective,
+        "proxy_origin": proxy::public_origin(&headers),
+    })))
+}
+
+/// POST /api/workspaces/{user_id}/start
+pub async fn start(
+    State(state): State<AppState>,
+    caller: AuthUser,
+    Path(user_id): Path<i32>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    caller.require("workspaces.write")?;
+    ensure_user_exists(&state, user_id).await?;
+    workspaces::ensure_started(&state, user_id).await?;
+    Ok(Json(serde_json::json!({ "status": "running" })))
+}
+
+/// POST /api/workspaces/{user_id}/stop: stops the workspace, keeps its volume.
+pub async fn stop(
+    State(state): State<AppState>,
+    caller: AuthUser,
+    Path(user_id): Path<i32>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    caller.require("workspaces.write")?;
+    workspaces::stop(&state, user_id).await?;
+    Ok(Json(serde_json::json!({ "status": "stopped" })))
+}
+
+/// DELETE /api/workspaces/{user_id}: destroys the workspace AND its volume.
+pub async fn destroy(
+    State(state): State<AppState>,
+    caller: AuthUser,
+    Path(user_id): Path<i32>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    caller.require("workspaces.write")?;
+    workspaces::destroy(&state, user_id).await?;
+    Ok(Json(serde_json::json!({ "destroyed": true })))
+}
+
+#[derive(Deserialize)]
+pub struct SetVersionRequest {
+    /// `null` (or empty) unpins, following the default version.
+    pub pinned_version: Option<String>,
+}
+
+/// PATCH /api/workspaces/{user_id}: pin or unpin the served aoe version. A
+/// running workspace is recreated (volume kept) on its next start or proxied
+/// request.
+pub async fn set_version(
+    State(state): State<AppState>,
+    caller: AuthUser,
+    Path(user_id): Path<i32>,
+    Json(body): Json<SetVersionRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    caller.require("workspaces.write")?;
+    ensure_user_exists(&state, user_id).await?;
+    pin_version(&state, user_id, body.pinned_version.clone()).await?;
+    Ok(Json(
+        serde_json::json!({ "pinned_version": normalize(body.pinned_version) }),
+    ))
+}
+
+#[derive(Deserialize)]
+pub struct BulkSetVersionRequest {
+    pub user_ids: Vec<i32>,
+    pub pinned_version: Option<String>,
+}
+
+/// PATCH /api/workspaces: pin/unpin a group of users in one call (grouped
+/// upgrade/downgrade).
+pub async fn bulk_set_version(
+    State(state): State<AppState>,
+    caller: AuthUser,
+    Json(body): Json<BulkSetVersionRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    caller.require("workspaces.write")?;
+    if body.user_ids.is_empty() {
+        return Err(AppError::BadRequest("user_ids is required"));
+    }
+    for user_id in &body.user_ids {
+        ensure_user_exists(&state, *user_id).await?;
+    }
+    for user_id in body.user_ids {
+        pin_version(&state, user_id, body.pinned_version.clone()).await?;
+    }
+    Ok(Json(
+        serde_json::json!({ "pinned_version": normalize(body.pinned_version) }),
+    ))
+}
+
+fn normalize(version: Option<String>) -> Option<String> {
+    version
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+async fn ensure_user_exists(state: &AppState, user_id: i32) -> Result<(), AppError> {
+    crate::entities::user::Entity::find_by_id(user_id)
+        .one(&state.db)
+        .await?
+        .ok_or(AppError::NotFound("user not found"))?;
+    Ok(())
+}
+
+async fn pin_version(
+    state: &AppState,
+    user_id: i32,
+    version: Option<String>,
+) -> Result<(), AppError> {
+    let row = workspaces::get_or_create(&state.db, user_id).await?;
+    let mut active: workspace::ActiveModel = row.into();
+    active.pinned_version = Set(normalize(version));
+    active.updated_at = Set(Utc::now());
+    active.update(&state.db).await?;
+    Ok(())
+}
+
+#[derive(Serialize)]
+pub struct WorkspaceSettingsResponse {
+    pub enabled: bool,
+    pub image_template: String,
+    pub default_version: Option<String>,
+    pub idle_stop_minutes: i32,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateWorkspaceSettingsRequest {
+    pub enabled: bool,
+    pub image_template: String,
+    pub default_version: Option<String>,
+    pub idle_stop_minutes: i32,
+}
+
+/// GET /api/settings/workspaces
+pub async fn get_settings(
+    State(state): State<AppState>,
+    caller: AuthUser,
+) -> Result<Json<WorkspaceSettingsResponse>, AppError> {
+    caller.require("settings.read")?;
+    let cfg = workspaces::settings(&state.db).await?;
+    Ok(Json(WorkspaceSettingsResponse {
+        enabled: cfg.enabled,
+        image_template: cfg.image_template,
+        default_version: cfg.default_version,
+        idle_stop_minutes: cfg.idle_stop_minutes,
+    }))
+}
+
+/// PUT /api/settings/workspaces
+pub async fn update_settings(
+    State(state): State<AppState>,
+    caller: AuthUser,
+    Json(body): Json<UpdateWorkspaceSettingsRequest>,
+) -> Result<Json<WorkspaceSettingsResponse>, AppError> {
+    caller.require("settings.write")?;
+    if body.image_template.trim().is_empty() {
+        return Err(AppError::BadRequest("image template is required"));
+    }
+    if body.idle_stop_minutes < 1 {
+        return Err(AppError::BadRequest("idle stop must be at least 1 minute"));
+    }
+    let default_version = normalize(body.default_version);
+    if body.enabled && default_version.is_none() {
+        return Err(AppError::BadRequest(
+            "a default version is required to enable workspaces",
+        ));
+    }
+
+    let existing = workspace_settings::Entity::find_by_id(SETTINGS_ID)
+        .one(&state.db)
+        .await?;
+    let model = workspace_settings::ActiveModel {
+        id: Set(SETTINGS_ID),
+        enabled: Set(body.enabled),
+        image_template: Set(body.image_template.trim().to_string()),
+        default_version: Set(default_version),
+        idle_stop_minutes: Set(body.idle_stop_minutes),
+        updated_at: Set(Utc::now()),
+    };
+    if existing.is_some() {
+        model.update(&state.db).await?;
+    } else {
+        model.insert(&state.db).await?;
+    }
+    get_settings(State(state), caller).await
+}

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -83,7 +83,6 @@ pub async fn me(
         .and_then(|r| workspaces::effective_version(&cfg, r))
         .or_else(|| cfg.default_version.clone());
     Ok(Json(serde_json::json!({
-        "enabled": cfg.enabled,
         "status": status,
         "pinned_version": row.as_ref().and_then(|r| r.pinned_version.clone()),
         "effective_version": effective,
@@ -205,7 +204,6 @@ async fn pin_version(
 
 #[derive(Serialize)]
 pub struct WorkspaceSettingsResponse {
-    pub enabled: bool,
     pub image_template: String,
     pub default_version: Option<String>,
     pub idle_stop_minutes: i32,
@@ -213,7 +211,6 @@ pub struct WorkspaceSettingsResponse {
 
 #[derive(Deserialize)]
 pub struct UpdateWorkspaceSettingsRequest {
-    pub enabled: bool,
     pub image_template: String,
     pub default_version: Option<String>,
     pub idle_stop_minutes: i32,
@@ -227,7 +224,6 @@ pub async fn get_settings(
     caller.require("settings.read")?;
     let cfg = workspaces::settings(&state.db).await?;
     Ok(Json(WorkspaceSettingsResponse {
-        enabled: cfg.enabled,
         image_template: cfg.image_template,
         default_version: cfg.default_version,
         idle_stop_minutes: cfg.idle_stop_minutes,
@@ -248,18 +244,12 @@ pub async fn update_settings(
         return Err(AppError::BadRequest("idle stop must be at least 1 minute"));
     }
     let default_version = normalize(body.default_version);
-    if body.enabled && default_version.is_none() {
-        return Err(AppError::BadRequest(
-            "a default version is required to enable workspaces",
-        ));
-    }
 
     let existing = workspace_settings::Entity::find_by_id(SETTINGS_ID)
         .one(&state.db)
         .await?;
     let model = workspace_settings::ActiveModel {
         id: Set(SETTINGS_ID),
-        enabled: Set(body.enabled),
         image_template: Set(body.image_template.trim().to_string()),
         default_version: Set(default_version),
         idle_stop_minutes: Set(body.idle_stop_minutes),

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -8,10 +8,14 @@ mod handlers;
 mod mailer;
 mod migration;
 mod oidc;
+mod orchestrator;
+mod proxy;
 mod rbac;
 mod seed;
 mod server;
 mod service;
+mod state;
+mod workspaces;
 
 use clap::Parser;
 

--- a/api/src/migration/m0011_create_workspaces.rs
+++ b/api/src/migration/m0011_create_workspaces.rs
@@ -32,14 +32,14 @@ impl MigrationTrait for Migration {
             .await?;
 
         // Single-row table (id is always 1) holding orchestration settings.
-        // Workspaces are off by default; an admin enables them in settings.
+        // Workspaces are always on (they are CityHall's core purpose); the
+        // settings only tune how they run.
         manager
             .create_table(
                 Table::create()
                     .table(WorkspaceSettings::Table)
                     .if_not_exists()
                     .col(integer(WorkspaceSettings::Id).primary_key())
-                    .col(boolean(WorkspaceSettings::Enabled).default(false))
                     .col(string(WorkspaceSettings::ImageTemplate).default("cityhall/aoe:{version}"))
                     .col(string_null(WorkspaceSettings::DefaultVersion))
                     .col(integer(WorkspaceSettings::IdleStopMinutes).default(30))
@@ -73,7 +73,6 @@ pub enum Workspaces {
 pub enum WorkspaceSettings {
     Table,
     Id,
-    Enabled,
     ImageTemplate,
     DefaultVersion,
     IdleStopMinutes,

--- a/api/src/migration/m0011_create_workspaces.rs
+++ b/api/src/migration/m0011_create_workspaces.rs
@@ -1,0 +1,81 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::schema::*;
+
+use super::m0001_create_users::Users;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // One row per user workspace. Only intent lives here (pinned version,
+        // activity checkpoint); runtime state is read from the orchestrator.
+        manager
+            .create_table(
+                Table::create()
+                    .table(Workspaces::Table)
+                    .if_not_exists()
+                    .col(integer(Workspaces::UserId).primary_key())
+                    .col(string_null(Workspaces::PinnedVersion))
+                    .col(timestamp_with_time_zone_null(Workspaces::LastActiveAt))
+                    .col(timestamp_with_time_zone(Workspaces::CreatedAt))
+                    .col(timestamp_with_time_zone(Workspaces::UpdatedAt))
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(Workspaces::Table, Workspaces::UserId)
+                            .to(Users::Table, Users::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        // Single-row table (id is always 1) holding orchestration settings.
+        // Workspaces are off by default; an admin enables them in settings.
+        manager
+            .create_table(
+                Table::create()
+                    .table(WorkspaceSettings::Table)
+                    .if_not_exists()
+                    .col(integer(WorkspaceSettings::Id).primary_key())
+                    .col(boolean(WorkspaceSettings::Enabled).default(false))
+                    .col(string(WorkspaceSettings::ImageTemplate).default("cityhall/aoe:{version}"))
+                    .col(string_null(WorkspaceSettings::DefaultVersion))
+                    .col(integer(WorkspaceSettings::IdleStopMinutes).default(30))
+                    .col(timestamp_with_time_zone(WorkspaceSettings::UpdatedAt))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(WorkspaceSettings::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Workspaces::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+pub enum Workspaces {
+    Table,
+    UserId,
+    PinnedVersion,
+    LastActiveAt,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+pub enum WorkspaceSettings {
+    Table,
+    Id,
+    Enabled,
+    ImageTemplate,
+    DefaultVersion,
+    IdleStopMinutes,
+    UpdatedAt,
+}

--- a/api/src/migration/mod.rs
+++ b/api/src/migration/mod.rs
@@ -10,6 +10,7 @@ mod m0007_create_oidc_settings;
 mod m0008_add_oidc_subject_to_users;
 mod m0009_create_auth_settings;
 mod m0010_add_email_verified_to_users;
+mod m0011_create_workspaces;
 
 pub struct Migrator;
 
@@ -27,6 +28,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0008_add_oidc_subject_to_users::Migration),
             Box::new(m0009_create_auth_settings::Migration),
             Box::new(m0010_add_email_verified_to_users::Migration),
+            Box::new(m0011_create_workspaces::Migration),
         ]
     }
 }

--- a/api/src/orchestrator/docker.rs
+++ b/api/src/orchestrator/docker.rs
@@ -1,0 +1,310 @@
+//! Docker CLI workspace backend.
+//!
+//! Shells out to the `docker` binary (override with `CONTAINER_CLI`, e.g.
+//! `podman`) rather than a docker API crate: the aoe ecosystem already drives
+//! containers through the CLI, it needs no extra dependencies, and only
+//! structured output (`--format '{{json .}}'`) is parsed. This backend assumes
+//! CityHall runs natively on the docker host and reaches workspaces through
+//! loopback-published ephemeral ports; other topologies are separate backends.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use tokio::process::Command;
+
+use super::{Orchestrator, OrchestratorError, WorkspaceSpec, WorkspaceStatus};
+
+/// Port aoe serves on inside the workspace container.
+const AOE_PORT: u16 = 8080;
+/// Where the aoe app dir lives inside the container (the reference image runs
+/// as user `aoe`); the per-user volume is mounted here.
+const AOE_DATA_DIR: &str = "/home/aoe/.config/agent-of-empires";
+const CLI_TIMEOUT: Duration = Duration::from_secs(60);
+/// How long to wait for aoe to accept connections after `docker start`.
+const READY_TIMEOUT: Duration = Duration::from_secs(15);
+
+pub fn container_name(user_id: i32) -> String {
+    format!("cityhall-workspace-u{user_id}")
+}
+
+pub fn volume_name(user_id: i32) -> String {
+    format!("cityhall-workspace-u{user_id}-data")
+}
+
+pub struct DockerCliOrchestrator {
+    cli: String,
+}
+
+impl DockerCliOrchestrator {
+    pub fn from_env() -> Self {
+        DockerCliOrchestrator {
+            cli: std::env::var("CONTAINER_CLI").unwrap_or_else(|_| "docker".to_string()),
+        }
+    }
+
+    /// Run the container CLI, returning stdout on success. `NotFound` is
+    /// reported as `Ok(None)` so callers can treat missing objects as state,
+    /// not failure.
+    async fn run(&self, args: &[&str]) -> Result<Option<String>, OrchestratorError> {
+        let mut cmd = Command::new(&self.cli);
+        cmd.args(args).kill_on_drop(true);
+        let output = tokio::time::timeout(CLI_TIMEOUT, cmd.output())
+            .await
+            .map_err(|_| {
+                OrchestratorError::Runtime(format!("{} {} timed out", self.cli, args.join(" ")))
+            })?
+            .map_err(|e| OrchestratorError::Runtime(format!("failed to run {}: {e}", self.cli)))?;
+
+        if output.status.success() {
+            return Ok(Some(String::from_utf8_lossy(&output.stdout).into_owned()));
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let lower = stderr.to_lowercase();
+        if lower.contains("no such") || lower.contains("not found") {
+            return Ok(None);
+        }
+        Err(OrchestratorError::Runtime(format!(
+            "{} {} failed: {}",
+            self.cli,
+            args.join(" "),
+            stderr.trim()
+        )))
+    }
+
+    async fn inspect(&self, name: &str) -> Result<Option<ContainerState>, OrchestratorError> {
+        let out = self
+            .run(&["container", "inspect", "--format", "{{json .}}", name])
+            .await?;
+        match out {
+            Some(json) => {
+                let raw: InspectOutput = serde_json::from_str(json.trim()).map_err(|e| {
+                    OrchestratorError::Runtime(format!("unparseable inspect output: {e}"))
+                })?;
+                Ok(Some(ContainerState {
+                    running: raw.state.running,
+                    version_label: raw
+                        .config
+                        .labels
+                        .and_then(|l| l.get("cityhall.workspace.version").cloned()),
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// The loopback address of the container's published aoe port.
+    async fn published_addr(&self, name: &str) -> Result<String, OrchestratorError> {
+        let port_arg = format!("{AOE_PORT}/tcp");
+        let out = self
+            .run(&["port", name, &port_arg])
+            .await?
+            .ok_or_else(|| OrchestratorError::Runtime(format!("container {name} not found")))?;
+        parse_published_addr(&out).ok_or_else(|| {
+            OrchestratorError::Runtime(format!("no published port for {name}: {out}"))
+        })
+    }
+
+    async fn image_exists(&self, image: &str) -> Result<bool, OrchestratorError> {
+        Ok(self
+            .run(&["image", "inspect", "--format", "{{.Id}}", image])
+            .await?
+            .is_some())
+    }
+
+    async fn create_and_start(&self, spec: &WorkspaceSpec) -> Result<(), OrchestratorError> {
+        if !self.image_exists(&spec.image).await? {
+            return Err(OrchestratorError::ImageMissing(format!(
+                "workspace image '{}' not found; build it first (see deploy/aoe-image/) \
+                 or fix the image template / version in the workspace settings",
+                spec.image
+            )));
+        }
+        let volume = volume_name(spec.user_id);
+        self.run(&[
+            "volume",
+            "create",
+            "--label",
+            "cityhall.managed=true",
+            &volume,
+        ])
+        .await?;
+
+        let name = container_name(spec.user_id);
+        let user_label = format!("cityhall.user_id={}", spec.user_id);
+        let version_label = format!("cityhall.workspace.version={}", spec.version);
+        let mount = format!("{volume}:{AOE_DATA_DIR}");
+        let publish = format!("127.0.0.1:0:{AOE_PORT}");
+        let port = AOE_PORT.to_string();
+        self.run(&[
+            "run",
+            "-d",
+            "--name",
+            &name,
+            "--label",
+            "cityhall.managed=true",
+            "--label",
+            &user_label,
+            "--label",
+            &version_label,
+            "-v",
+            &mount,
+            "-p",
+            &publish,
+            &spec.image,
+            "aoe",
+            "serve",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            &port,
+            // CityHall's session gates the proxy; the container port is only
+            // published on loopback.
+            "--auth",
+            "none",
+            "--behind-proxy",
+        ])
+        .await?;
+        Ok(())
+    }
+
+    /// Wait until the workspace accepts TCP connections so the first proxied
+    /// request does not race aoe's startup.
+    async fn wait_ready(&self, addr: &str) -> Result<(), OrchestratorError> {
+        let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
+        loop {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(OrchestratorError::Runtime(format!(
+                    "workspace at {addr} did not become ready within {READY_TIMEOUT:?}"
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+}
+
+#[async_trait]
+impl Orchestrator for DockerCliOrchestrator {
+    async fn ensure_started(&self, spec: &WorkspaceSpec) -> Result<String, OrchestratorError> {
+        let name = container_name(spec.user_id);
+        match self.inspect(&name).await? {
+            Some(state) if state.version_label.as_deref() != Some(spec.version.as_str()) => {
+                // Version drift: recreate the container, keeping the volume.
+                tracing::info!(
+                    user_id = spec.user_id,
+                    from = state.version_label.as_deref().unwrap_or("unknown"),
+                    to = %spec.version,
+                    "recreating workspace for version change"
+                );
+                self.run(&["rm", "-f", &name]).await?;
+                self.create_and_start(spec).await?;
+            }
+            Some(state) if state.running => {}
+            Some(_) => {
+                self.run(&["start", &name]).await?;
+            }
+            None => {
+                self.create_and_start(spec).await?;
+            }
+        }
+        let addr = self.published_addr(&name).await?;
+        self.wait_ready(&addr).await?;
+        Ok(addr)
+    }
+
+    async fn stop(&self, user_id: i32) -> Result<(), OrchestratorError> {
+        self.run(&["stop", "-t", "10", &container_name(user_id)])
+            .await?;
+        Ok(())
+    }
+
+    async fn destroy(&self, user_id: i32) -> Result<(), OrchestratorError> {
+        self.run(&["rm", "-f", &container_name(user_id)]).await?;
+        self.run(&["volume", "rm", &volume_name(user_id)]).await?;
+        Ok(())
+    }
+
+    async fn status(&self, user_id: i32) -> Result<WorkspaceStatus, OrchestratorError> {
+        let name = container_name(user_id);
+        match self.inspect(&name).await? {
+            None => Ok(WorkspaceStatus::NotCreated),
+            Some(state) if state.running => Ok(WorkspaceStatus::Running {
+                addr: self.published_addr(&name).await?,
+            }),
+            Some(_) => Ok(WorkspaceStatus::Stopped),
+        }
+    }
+}
+
+struct ContainerState {
+    running: bool,
+    version_label: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct InspectOutput {
+    #[serde(rename = "State")]
+    state: InspectState,
+    #[serde(rename = "Config")]
+    config: InspectConfig,
+}
+
+#[derive(Deserialize)]
+struct InspectState {
+    #[serde(rename = "Running")]
+    running: bool,
+}
+
+#[derive(Deserialize)]
+struct InspectConfig {
+    #[serde(rename = "Labels")]
+    labels: Option<std::collections::HashMap<String, String>>,
+}
+
+/// Parse `docker port` output (`127.0.0.1:55000`, possibly multiple lines with
+/// an IPv6 line like `[::1]:55000`) into a dialable loopback address.
+fn parse_published_addr(out: &str) -> Option<String> {
+    out.lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('['))
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_are_deterministic() {
+        assert_eq!(container_name(42), "cityhall-workspace-u42");
+        assert_eq!(volume_name(42), "cityhall-workspace-u42-data");
+    }
+
+    #[test]
+    fn parse_port_output() {
+        assert_eq!(
+            parse_published_addr("127.0.0.1:55000\n").as_deref(),
+            Some("127.0.0.1:55000")
+        );
+        // IPv4 line preferred over the IPv6 one regardless of order.
+        assert_eq!(
+            parse_published_addr("[::1]:55000\n127.0.0.1:55000\n").as_deref(),
+            Some("127.0.0.1:55000")
+        );
+        assert_eq!(parse_published_addr(""), None);
+    }
+
+    #[test]
+    fn inspect_json_parses() {
+        let json = r#"{"State":{"Running":true},"Config":{"Labels":{"cityhall.workspace.version":"v1.0.0"}}}"#;
+        let raw: InspectOutput = serde_json::from_str(json).unwrap();
+        assert!(raw.state.running);
+        assert_eq!(
+            raw.config.labels.unwrap().get("cityhall.workspace.version"),
+            Some(&"v1.0.0".to_string())
+        );
+    }
+}

--- a/api/src/orchestrator/docker.rs
+++ b/api/src/orchestrator/docker.rs
@@ -168,12 +168,12 @@ impl DockerCliOrchestrator {
         Ok(())
     }
 
-    /// Wait until the workspace accepts TCP connections so the first proxied
-    /// request does not race aoe's startup.
+    /// Wait until the workspace answers HTTP so the first proxied request does
+    /// not race aoe's startup.
     async fn wait_ready(&self, addr: &str) -> Result<(), OrchestratorError> {
         let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
         loop {
-            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            if http_probe(addr).await {
                 return Ok(());
             }
             if tokio::time::Instant::now() >= deadline {
@@ -264,6 +264,31 @@ struct InspectConfig {
     labels: Option<std::collections::HashMap<String, String>>,
 }
 
+/// Whether an HTTP server answers at `addr`. A bare TCP connect is not
+/// enough: docker's userland proxy accepts connections on the published port
+/// before the service inside the container listens, so the probe must
+/// actually exchange bytes.
+async fn http_probe(addr: &str) -> bool {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let probe = async {
+        let mut stream = tokio::net::TcpStream::connect(addr).await.ok()?;
+        stream
+            .write_all(b"GET / HTTP/1.0\r\nHost: workspace\r\n\r\n")
+            .await
+            .ok()?;
+        let mut buf = [0u8; 1];
+        match stream.read(&mut buf).await {
+            Ok(n) if n > 0 => Some(()),
+            _ => None,
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(2), probe)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+}
+
 /// Parse `docker port` output (`127.0.0.1:55000`, possibly multiple lines with
 /// an IPv6 line like `[::1]:55000`) into a dialable loopback address.
 fn parse_published_addr(out: &str) -> Option<String> {
@@ -295,6 +320,30 @@ mod tests {
             Some("127.0.0.1:55000")
         );
         assert_eq!(parse_published_addr(""), None);
+    }
+
+    #[tokio::test]
+    async fn http_probe_requires_a_response_not_just_a_connect() {
+        use tokio::io::AsyncWriteExt;
+
+        // Accepts and answers: ready.
+        let responder = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = responder.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            let (mut sock, _) = responder.accept().await.unwrap();
+            let _ = sock.write_all(b"HTTP/1.0 200 OK\r\n\r\n").await;
+        });
+        assert!(http_probe(&addr).await);
+
+        // Accepts but closes without a byte (docker-proxy with no backend
+        // yet): not ready.
+        let closer = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = closer.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            let (sock, _) = closer.accept().await.unwrap();
+            drop(sock);
+        });
+        assert!(!http_probe(&addr).await);
     }
 
     #[test]

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -1,0 +1,94 @@
+//! Backend-agnostic orchestration seam for per-user aoe workspaces.
+//!
+//! A workspace is one long-lived aoe instance (container, process, pod...)
+//! per user with a persistent data volume. Backends implement [`Orchestrator`];
+//! CityHall stores only intent (pinned version, activity) in the database and
+//! treats the runtime as the source of truth for liveness.
+
+pub mod docker;
+
+use async_trait::async_trait;
+
+/// Everything a backend needs to materialize a user's workspace.
+#[derive(Clone, Debug)]
+pub struct WorkspaceSpec {
+    pub user_id: i32,
+    /// Fully rendered image reference (docker/kube backends).
+    pub image: String,
+    /// The aoe version the image serves; used to detect version drift.
+    pub version: String,
+}
+
+/// Runtime state of a workspace as reported by the backend.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkspaceStatus {
+    /// No runtime object exists (never started, or destroyed).
+    NotCreated,
+    /// Exists but is not running; the data volume is retained.
+    Stopped,
+    /// Running and reachable at `addr` (`host:port`).
+    Running { addr: String },
+}
+
+#[derive(Debug)]
+pub enum OrchestratorError {
+    /// The workspace image is not available; carries operator guidance.
+    ImageMissing(String),
+    /// Any other backend failure (daemon down, command failed...).
+    Runtime(String),
+}
+
+impl std::fmt::Display for OrchestratorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OrchestratorError::ImageMissing(m) | OrchestratorError::Runtime(m) => {
+                write!(f, "{m}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for OrchestratorError {}
+
+/// Lifecycle contract every workspace backend implements. All operations are
+/// idempotent: stopping a missing workspace succeeds, destroying twice
+/// succeeds.
+#[async_trait]
+pub trait Orchestrator: Send + Sync {
+    /// Reconcile the user's workspace to "running with `spec`" and return its
+    /// reachable address. Recreates the runtime object (keeping the volume)
+    /// when the running version differs from `spec.version`.
+    async fn ensure_started(&self, spec: &WorkspaceSpec) -> Result<String, OrchestratorError>;
+
+    /// Stop the workspace, keeping its data volume.
+    async fn stop(&self, user_id: i32) -> Result<(), OrchestratorError>;
+
+    /// Remove the workspace AND its data volume.
+    async fn destroy(&self, user_id: i32) -> Result<(), OrchestratorError>;
+
+    /// Current runtime state.
+    async fn status(&self, user_id: i32) -> Result<WorkspaceStatus, OrchestratorError>;
+}
+
+/// Render an image template by substituting the `{version}` placeholder.
+pub fn render_image(template: &str, version: &str) -> String {
+    template.replace("{version}", version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_image_substitutes_version() {
+        assert_eq!(
+            render_image("cityhall/aoe:{version}", "v1.2.3"),
+            "cityhall/aoe:v1.2.3"
+        );
+        // A template without the placeholder pins every user to one image.
+        assert_eq!(
+            render_image("cityhall/aoe:latest", "v1"),
+            "cityhall/aoe:latest"
+        );
+    }
+}

--- a/api/src/proxy.rs
+++ b/api/src/proxy.rs
@@ -1,0 +1,305 @@
+//! Workspace reverse proxy.
+//!
+//! Served on a dedicated second listener (not a path prefix of the main app):
+//! the aoe dashboard uses root-absolute asset and WebSocket paths, so it gets
+//! its own origin. In development that is just another loopback port; cookies
+//! are host-scoped (ports ignored), so the regular CityHall session cookie
+//! authenticates here with zero extra configuration, while browser origin
+//! isolation still holds. In production the operator maps a subdomain or a
+//! second external port to this listener.
+//!
+//! Every request is gated on the CityHall session (`workspaces.use`), request-
+//! starts the caller's workspace, and is forwarded to it. The workspace itself
+//! runs `aoe serve --auth=none --behind-proxy` and is only reachable through
+//! loopback, so CityHall is the sole auth boundary.
+
+use std::net::SocketAddr;
+
+use axum::body::Body;
+use axum::extract::{ConnectInfo, FromRequestParts, State};
+use axum::http::header::{
+    HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONNECTION, CONTENT_LENGTH, COOKIE, HOST,
+    SEC_WEBSOCKET_EXTENSIONS, SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_PROTOCOL, SEC_WEBSOCKET_VERSION,
+    TRANSFER_ENCODING, UPGRADE,
+};
+use axum::http::{request, Request, Response, StatusCode, Version};
+use axum::response::IntoResponse;
+use axum::Router;
+use hyper_util::rt::TokioIo;
+use tower_http::trace::TraceLayer;
+
+use crate::auth::AuthUser;
+use crate::error::AppError;
+use crate::state::AppState;
+use crate::workspaces;
+
+/// Address of the workspace proxy listener.
+pub fn bind_addr() -> String {
+    std::env::var("WORKSPACE_PROXY_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3001".to_string())
+}
+
+/// The origin browsers should use to reach the workspace proxy: the
+/// `WORKSPACE_PROXY_PUBLIC_ORIGIN` override (production, behind a reverse
+/// proxy), or the request's hostname with the proxy port (development).
+pub fn public_origin(headers: &HeaderMap) -> String {
+    if let Ok(origin) = std::env::var("WORKSPACE_PROXY_PUBLIC_ORIGIN") {
+        return origin.trim_end_matches('/').to_string();
+    }
+    let host = headers
+        .get(HOST)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("127.0.0.1");
+    let hostname = host.rsplit_once(':').map(|(h, _)| h).unwrap_or(host);
+    let bind = bind_addr();
+    let port = bind.rsplit_once(':').map(|(_, p)| p).unwrap_or("3001");
+    format!("http://{hostname}:{port}")
+}
+
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .fallback(handler)
+        .with_state(state)
+        .layer(TraceLayer::new_for_http())
+}
+
+async fn handler(State(state): State<AppState>, req: Request<Body>) -> Response<Body> {
+    match proxy(state, req).await {
+        Ok(resp) => resp,
+        Err(e) => e.into_response(),
+    }
+}
+
+async fn proxy(state: AppState, req: Request<Body>) -> Result<Response<Body>, AppError> {
+    let (mut parts, body) = req.into_parts();
+    let caller = AuthUser::from_request_parts(&mut parts, &state).await?;
+    caller.require("workspaces.use")?;
+    let user_id = caller.user.id;
+
+    // Request-driven start: any hit on the proxy resumes a stopped workspace.
+    let addr = workspaces::ensure_started(&state, user_id).await?;
+    state.activity.touch(user_id);
+
+    let path_q = parts
+        .uri
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+    let target = format!("http://{addr}{path_q}");
+
+    if is_websocket_upgrade(&parts.headers) {
+        websocket_tunnel(&state, &mut parts, &target, user_id).await
+    } else {
+        http_forward(&state, &parts, body, &target).await
+    }
+}
+
+fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
+    headers
+        .get(UPGRADE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.eq_ignore_ascii_case("websocket"))
+}
+
+/// Hop-by-hop headers plus CityHall credentials and inbound forwarding
+/// headers; none of these may reach the workspace.
+const SKIP_REQUEST_HEADERS: &[HeaderName] = &[
+    HOST,
+    CONNECTION,
+    UPGRADE,
+    TRANSFER_ENCODING,
+    CONTENT_LENGTH,
+    COOKIE,
+    AUTHORIZATION,
+];
+
+fn forward_headers(parts: &request::Parts) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for (name, value) in &parts.headers {
+        let lower = name.as_str();
+        if SKIP_REQUEST_HEADERS.contains(name)
+            || lower.starts_with("x-forwarded-")
+            || lower == "keep-alive"
+            || lower == "te"
+            || lower == "trailer"
+            || lower.starts_with("proxy-")
+        {
+            continue;
+        }
+        headers.append(name.clone(), value.clone());
+    }
+    if let Some(host) = parts.headers.get(HOST) {
+        headers.insert("x-forwarded-host", host.clone());
+    }
+    headers.insert("x-forwarded-proto", HeaderValue::from_static("http"));
+    if let Some(ConnectInfo(peer)) = parts.extensions.get::<ConnectInfo<SocketAddr>>() {
+        if let Ok(v) = HeaderValue::from_str(&peer.ip().to_string()) {
+            headers.insert("x-forwarded-for", v);
+        }
+    }
+    headers
+}
+
+async fn http_forward(
+    state: &AppState,
+    parts: &request::Parts,
+    body: Body,
+    target: &str,
+) -> Result<Response<Body>, AppError> {
+    let upstream = state
+        .proxy_client
+        .request(parts.method.clone(), target)
+        .headers(forward_headers(parts))
+        .body(reqwest::Body::wrap_stream(body.into_data_stream()))
+        .send()
+        .await
+        .map_err(|e| AppError::WorkspaceUnavailable(format!("workspace request failed: {e}")))?;
+
+    let mut builder = Response::builder().status(upstream.status());
+    for (name, value) in upstream.headers() {
+        let lower = name.as_str();
+        if lower == "connection" || lower == "keep-alive" || lower == "transfer-encoding" {
+            continue;
+        }
+        builder = builder.header(name, value);
+    }
+    builder
+        .body(Body::from_stream(upstream.bytes_stream()))
+        .map_err(|_| AppError::Internal("failed to build proxied response"))
+}
+
+/// Bridge a WebSocket: proxy the handshake to the workspace, and only after
+/// its `101` return one downstream, then blindly pipe bytes both ways. The
+/// tunnel holds an activity lease so the idle sweeper never cuts a live
+/// terminal.
+async fn websocket_tunnel(
+    state: &AppState,
+    parts: &mut request::Parts,
+    target: &str,
+    user_id: i32,
+) -> Result<Response<Body>, AppError> {
+    let on_upgrade = parts
+        .extensions
+        .remove::<hyper::upgrade::OnUpgrade>()
+        .ok_or(AppError::BadRequest("connection is not upgradable"))?;
+
+    let mut headers = forward_headers(parts);
+    headers.insert(UPGRADE, HeaderValue::from_static("websocket"));
+    headers.insert(CONNECTION, HeaderValue::from_static("Upgrade"));
+    for name in [
+        SEC_WEBSOCKET_KEY,
+        SEC_WEBSOCKET_VERSION,
+        SEC_WEBSOCKET_PROTOCOL,
+        SEC_WEBSOCKET_EXTENSIONS,
+    ] {
+        if let Some(v) = parts.headers.get(&name) {
+            headers.insert(name, v.clone());
+        }
+    }
+
+    let upstream = state
+        .proxy_client
+        .get(target)
+        .version(Version::HTTP_11)
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|e| AppError::WorkspaceUnavailable(format!("workspace handshake failed: {e}")))?;
+
+    if upstream.status() != StatusCode::SWITCHING_PROTOCOLS {
+        return Err(AppError::WorkspaceUnavailable(format!(
+            "workspace rejected websocket upgrade: {}",
+            upstream.status()
+        )));
+    }
+
+    // Echo the workspace's actual negotiation (accept key, selected
+    // subprotocol, extensions), never the client's request.
+    let mut builder = Response::builder().status(StatusCode::SWITCHING_PROTOCOLS);
+    for name in [
+        UPGRADE,
+        CONNECTION,
+        HeaderName::from_static("sec-websocket-accept"),
+        SEC_WEBSOCKET_PROTOCOL,
+        SEC_WEBSOCKET_EXTENSIONS,
+    ] {
+        if let Some(v) = upstream.headers().get(&name) {
+            builder = builder.header(name, v.clone());
+        }
+    }
+    let response = builder
+        .body(Body::empty())
+        .map_err(|_| AppError::Internal("failed to build upgrade response"))?;
+
+    let activity = state.activity.clone();
+    activity.websocket_started(user_id);
+    tokio::spawn(async move {
+        let result = async {
+            let upstream_io = upstream
+                .upgrade()
+                .await
+                .map_err(|e| format!("upstream upgrade failed: {e}"))?;
+            let downstream_io = on_upgrade
+                .await
+                .map_err(|e| format!("downstream upgrade failed: {e}"))?;
+            let mut downstream = TokioIo::new(downstream_io);
+            let mut upstream = upstream_io;
+            tokio::io::copy_bidirectional(&mut downstream, &mut upstream)
+                .await
+                .map_err(|e| format!("tunnel closed with error: {e}"))?;
+            Ok::<_, String>(())
+        }
+        .await;
+        if let Err(e) = result {
+            tracing::debug!(user_id, "websocket tunnel ended: {e}");
+        }
+        activity.websocket_ended(user_id);
+    });
+
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn websocket_detection() {
+        let mut headers = HeaderMap::new();
+        assert!(!is_websocket_upgrade(&headers));
+        headers.insert(UPGRADE, HeaderValue::from_static("websocket"));
+        assert!(is_websocket_upgrade(&headers));
+        headers.insert(UPGRADE, HeaderValue::from_static("WebSocket"));
+        assert!(is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn public_origin_derives_from_request_host() {
+        let mut headers = HeaderMap::new();
+        headers.insert(HOST, HeaderValue::from_static("cityhall.local:3000"));
+        // No env override in tests; derived from hostname + proxy port.
+        assert_eq!(public_origin(&headers), "http://cityhall.local:3001");
+    }
+
+    #[test]
+    fn forwarded_headers_strip_credentials() {
+        let (mut parts, _) = Request::new(Body::empty()).into_parts();
+        parts
+            .headers
+            .insert(COOKIE, HeaderValue::from_static("cityhall_session=x"));
+        parts
+            .headers
+            .insert(AUTHORIZATION, HeaderValue::from_static("Bearer y"));
+        parts
+            .headers
+            .insert("x-forwarded-for", HeaderValue::from_static("1.2.3.4"));
+        parts
+            .headers
+            .insert("accept", HeaderValue::from_static("text/html"));
+        let out = forward_headers(&parts);
+        assert!(out.get(COOKIE).is_none());
+        assert!(out.get(AUTHORIZATION).is_none());
+        // Inbound spoofable forwarding headers are dropped, not passed on.
+        assert!(out.get("x-forwarded-for").is_none());
+        assert_eq!(out.get("accept").unwrap(), "text/html");
+    }
+}

--- a/api/src/rbac.rs
+++ b/api/src/rbac.rs
@@ -25,13 +25,20 @@ pub const CATALOG: &[(&str, &str)] = &[
     ("roles.write", "Create, edit, and delete roles"),
     ("settings.read", "View settings"),
     ("settings.write", "Change settings"),
+    ("workspaces.use", "Use your own workspace"),
+    ("workspaces.read", "View all workspaces"),
+    ("workspaces.write", "Manage workspaces and their versions"),
 ];
 
 /// Built-in roles seeded on startup: (name, description, permission keys).
 pub fn system_roles() -> Vec<(&'static str, &'static str, Vec<&'static str>)> {
     vec![
         (ADMIN_ROLE, "Full access to everything", vec![WILDCARD]),
-        (MEMBER_ROLE, "Basic access", vec!["users.read"]),
+        (
+            MEMBER_ROLE,
+            "Basic access",
+            vec!["users.read", "workspaces.use"],
+        ),
     ]
 }
 

--- a/api/src/seed.rs
+++ b/api/src/seed.rs
@@ -29,6 +29,22 @@ pub async fn ensure_roles(db: &DatabaseConnection) -> Result<(), AppError> {
         }
     }
 
+    // Existing installs seeded `member` before workspaces existed; grant the
+    // new default-member key in place so workspaces work out of the box.
+    // Only the system member role is touched, never operator-created roles.
+    if let Some(member) = service::find_role_by_name(db, rbac::MEMBER_ROLE).await? {
+        if member.is_system {
+            let mut keys: Vec<String> =
+                serde_json::from_str(&member.permissions).unwrap_or_default();
+            if !keys.iter().any(|k| k == "workspaces.use") {
+                keys.push("workspaces.use".to_string());
+                let mut active: role::ActiveModel = member.into();
+                active.permissions = Set(rbac::encode(&keys));
+                active.update(db).await?;
+            }
+        }
+    }
+
     let admin = service::find_role_by_name(db, rbac::ADMIN_ROLE)
         .await?
         .ok_or(AppError::Internal("admin role missing after seeding"))?;

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1,4 +1,6 @@
+use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use axum::routing::{get, patch, post};
 use axum::Router;
@@ -7,7 +9,10 @@ use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 
 use crate::error::AppError;
-use crate::handlers::{auth, oidc, roles, settings, signup, users};
+use crate::handlers::{auth, oidc, roles, settings, signup, users, workspaces};
+use crate::orchestrator::docker::DockerCliOrchestrator;
+use crate::proxy;
+use crate::state::AppState;
 
 /// Directory holding the built frontend. Overridable via `STATIC_DIR` for
 /// container images that place the bundle elsewhere.
@@ -17,7 +22,7 @@ fn static_dir() -> PathBuf {
         .into()
 }
 
-pub fn api_router(db: DatabaseConnection) -> Router {
+pub fn api_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(|| async { "ok" }))
         .route("/auth/login", post(auth::login))
@@ -39,6 +44,17 @@ pub fn api_router(db: DatabaseConnection) -> Router {
         .route("/roles", get(roles::list).post(roles::create))
         .route("/roles/{id}", patch(roles::update).delete(roles::delete))
         .route("/permissions", get(roles::permissions))
+        .route(
+            "/workspaces",
+            get(workspaces::list).patch(workspaces::bulk_set_version),
+        )
+        .route("/workspaces/me", get(workspaces::me))
+        .route(
+            "/workspaces/{user_id}",
+            patch(workspaces::set_version).delete(workspaces::destroy),
+        )
+        .route("/workspaces/{user_id}/start", post(workspaces::start))
+        .route("/workspaces/{user_id}/stop", post(workspaces::stop))
         .route("/settings/smtp", get(settings::get).put(settings::update))
         .route("/settings/smtp/test", post(settings::test))
         .route(
@@ -49,13 +65,17 @@ pub fn api_router(db: DatabaseConnection) -> Router {
             "/settings/signup",
             get(signup::get_settings).put(signup::update_settings),
         )
+        .route(
+            "/settings/workspaces",
+            get(workspaces::get_settings).put(workspaces::update_settings),
+        )
         // Unknown /api/* paths return a JSON 404 instead of falling through to
         // the SPA index (which the outer fallback_service would otherwise serve).
         .fallback(|| async { AppError::NotFound("not found") })
-        .with_state(db)
+        .with_state(state)
 }
 
-pub fn router(db: DatabaseConnection) -> Router {
+pub fn router(state: AppState) -> Router {
     let dir = static_dir();
     // Serve the SPA: static assets first, fall back to index.html so client
     // routes (e.g. /login) resolve on hard refresh.
@@ -65,15 +85,45 @@ pub fn router(db: DatabaseConnection) -> Router {
     let spa = ServeDir::new(&dir).fallback(ServeFile::new(index));
 
     Router::new()
-        .nest("/api", api_router(db))
+        .nest("/api", api_router(state))
         .fallback_service(spa)
         .layer(TraceLayer::new_for_http())
 }
 
+pub fn build_state(db: DatabaseConnection) -> Result<AppState, Box<dyn std::error::Error>> {
+    // HTTP/1.1 only and no redirect following: WebSocket upgrades need 1.1,
+    // and a proxy passes redirects through rather than chasing them.
+    let proxy_client = reqwest::Client::builder()
+        .http1_only()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+    Ok(AppState {
+        db,
+        orchestrator: Arc::new(DockerCliOrchestrator::from_env()),
+        activity: Arc::default(),
+        locks: Arc::default(),
+        proxy_client,
+    })
+}
+
 pub async fn serve(db: DatabaseConnection) -> Result<(), Box<dyn std::error::Error>> {
+    let state = build_state(db)?;
+    tokio::spawn(crate::workspaces::idle_sweeper(state.clone()));
+
     let addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     tracing::info!("cityhall listening on http://{addr}");
-    axum::serve(listener, router(db)).await?;
+
+    let proxy_addr = proxy::bind_addr();
+    let proxy_listener = tokio::net::TcpListener::bind(&proxy_addr).await?;
+    tracing::info!("workspace proxy listening on http://{proxy_addr}");
+
+    let main_srv = axum::serve(listener, router(state.clone()));
+    // ConnectInfo gives the proxy the peer IP for X-Forwarded-For.
+    let proxy_srv = axum::serve(
+        proxy_listener,
+        proxy::router(state).into_make_service_with_connect_info::<SocketAddr>(),
+    );
+    tokio::try_join!(main_srv, proxy_srv)?;
     Ok(())
 }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -108,6 +108,7 @@ pub fn build_state(db: DatabaseConnection) -> Result<AppState, Box<dyn std::erro
 
 pub async fn serve(db: DatabaseConnection) -> Result<(), Box<dyn std::error::Error>> {
     let state = build_state(db)?;
+    crate::workspaces::seed_default_version(&state.db).await?;
     tokio::spawn(crate::workspaces::idle_sweeper(state.clone()));
 
     let addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -1,0 +1,121 @@
+//! Shared application state threaded through axum.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use axum::extract::FromRef;
+use sea_orm::DatabaseConnection;
+
+use crate::orchestrator::Orchestrator;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub db: DatabaseConnection,
+    pub orchestrator: Arc<dyn Orchestrator>,
+    pub activity: Arc<ActivityRegistry>,
+    pub locks: Arc<WorkspaceLocks>,
+    /// Client for proxied HTTP requests to workspaces (no redirects, HTTP/1.1
+    /// so WebSocket upgrades tunnel through).
+    pub proxy_client: reqwest::Client,
+}
+
+/// Lets existing handlers keep extracting `State<DatabaseConnection>`.
+impl FromRef<AppState> for DatabaseConnection {
+    fn from_ref(state: &AppState) -> Self {
+        state.db.clone()
+    }
+}
+
+/// In-memory per-user workspace activity. The hot path (every proxied request)
+/// only touches memory; the idle sweeper checkpoints coarse timestamps to the
+/// database.
+#[derive(Default)]
+pub struct ActivityRegistry {
+    entries: Mutex<HashMap<i32, ActivityEntry>>,
+}
+
+#[derive(Clone, Copy)]
+pub struct ActivityEntry {
+    pub last_seen: Instant,
+    /// Open proxied WebSocket tunnels; a workspace with a live tunnel is never
+    /// idle-stopped even if no HTTP requests arrive.
+    pub active_websockets: u32,
+}
+
+impl ActivityRegistry {
+    pub fn touch(&self, user_id: i32) {
+        let mut entries = self.entries.lock().unwrap();
+        let entry = entries.entry(user_id).or_insert(ActivityEntry {
+            last_seen: Instant::now(),
+            active_websockets: 0,
+        });
+        entry.last_seen = Instant::now();
+    }
+
+    pub fn websocket_started(&self, user_id: i32) {
+        let mut entries = self.entries.lock().unwrap();
+        let entry = entries.entry(user_id).or_insert(ActivityEntry {
+            last_seen: Instant::now(),
+            active_websockets: 0,
+        });
+        entry.active_websockets += 1;
+        entry.last_seen = Instant::now();
+    }
+
+    pub fn websocket_ended(&self, user_id: i32) {
+        let mut entries = self.entries.lock().unwrap();
+        if let Some(entry) = entries.get_mut(&user_id) {
+            entry.active_websockets = entry.active_websockets.saturating_sub(1);
+            entry.last_seen = Instant::now();
+        }
+    }
+
+    pub fn get(&self, user_id: i32) -> Option<ActivityEntry> {
+        self.entries.lock().unwrap().get(&user_id).copied()
+    }
+}
+
+/// Per-user async locks serializing workspace lifecycle transitions, so a
+/// proxy-triggered start cannot race the idle sweeper's stop (or a concurrent
+/// first-page-load double-start).
+#[derive(Default)]
+pub struct WorkspaceLocks {
+    locks: Mutex<HashMap<i32, Arc<tokio::sync::Mutex<()>>>>,
+}
+
+impl WorkspaceLocks {
+    pub fn lock_for(&self, user_id: i32) -> Arc<tokio::sync::Mutex<()>> {
+        self.locks
+            .lock()
+            .unwrap()
+            .entry(user_id)
+            .or_default()
+            .clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn websocket_leases_track_open_tunnels() {
+        let reg = ActivityRegistry::default();
+        reg.websocket_started(1);
+        reg.websocket_started(1);
+        assert_eq!(reg.get(1).unwrap().active_websockets, 2);
+        reg.websocket_ended(1);
+        assert_eq!(reg.get(1).unwrap().active_websockets, 1);
+        reg.websocket_ended(1);
+        // Underflow is clamped rather than wrapping.
+        reg.websocket_ended(1);
+        assert_eq!(reg.get(1).unwrap().active_websockets, 0);
+    }
+
+    #[test]
+    fn unknown_user_has_no_entry() {
+        let reg = ActivityRegistry::default();
+        assert!(reg.get(99).is_none());
+    }
+}

--- a/api/src/workspaces.rs
+++ b/api/src/workspaces.rs
@@ -1,0 +1,285 @@
+//! Workspace policy layer: settings resolution, intent rows, lifecycle entry
+//! points shared by the API handlers and the proxy, and the idle-stop sweeper.
+
+use std::time::Duration;
+
+use chrono::Utc;
+use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set};
+
+use crate::entities::{workspace, workspace_settings};
+use crate::error::AppError;
+use crate::orchestrator::{render_image, OrchestratorError, WorkspaceSpec, WorkspaceStatus};
+use crate::state::AppState;
+
+pub const SETTINGS_ID: i32 = 1;
+const SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Effective workspace settings: the stored row, or defaults when none exists.
+pub async fn settings(db: &DatabaseConnection) -> Result<workspace_settings::Model, AppError> {
+    Ok(workspace_settings::Entity::find_by_id(SETTINGS_ID)
+        .one(db)
+        .await?
+        .unwrap_or(workspace_settings::Model {
+            id: SETTINGS_ID,
+            enabled: false,
+            image_template: "cityhall/aoe:{version}".to_string(),
+            default_version: None,
+            idle_stop_minutes: 30,
+            updated_at: Utc::now(),
+        }))
+}
+
+/// The user's workspace intent row, created on first use.
+pub async fn get_or_create(
+    db: &DatabaseConnection,
+    user_id: i32,
+) -> Result<workspace::Model, AppError> {
+    if let Some(row) = workspace::Entity::find_by_id(user_id).one(db).await? {
+        return Ok(row);
+    }
+    let now = Utc::now();
+    Ok(workspace::ActiveModel {
+        user_id: Set(user_id),
+        pinned_version: Set(None),
+        last_active_at: Set(Some(now)),
+        created_at: Set(now),
+        updated_at: Set(now),
+    }
+    .insert(db)
+    .await?)
+}
+
+/// The aoe version this workspace should run: its pin, or the global default.
+pub fn effective_version(
+    settings: &workspace_settings::Model,
+    row: &workspace::Model,
+) -> Option<String> {
+    row.pinned_version
+        .clone()
+        .or_else(|| settings.default_version.clone())
+}
+
+pub fn build_spec(
+    settings: &workspace_settings::Model,
+    row: &workspace::Model,
+) -> Result<WorkspaceSpec, AppError> {
+    let version = effective_version(settings, row).ok_or(AppError::BadRequest(
+        "no workspace version configured; set a default version in the workspace settings",
+    ))?;
+    Ok(WorkspaceSpec {
+        user_id: row.user_id,
+        image: render_image(&settings.image_template, &version),
+        version,
+    })
+}
+
+impl From<OrchestratorError> for AppError {
+    fn from(e: OrchestratorError) -> Self {
+        AppError::WorkspaceUnavailable(e.to_string())
+    }
+}
+
+/// Start (or resume) `user_id`'s workspace and return its address. This is the
+/// request-driven start path: the proxy calls it on every request, the admin
+/// start endpoint calls it explicitly. Serialized per user against the sweeper.
+pub async fn ensure_started(state: &AppState, user_id: i32) -> Result<String, AppError> {
+    let cfg = settings(&state.db).await?;
+    if !cfg.enabled {
+        return Err(AppError::WorkspaceUnavailable(
+            "workspaces are disabled; an admin can enable them in settings".to_string(),
+        ));
+    }
+    let row = get_or_create(&state.db, user_id).await?;
+    let spec = build_spec(&cfg, &row)?;
+
+    let lock = state.locks.lock_for(user_id);
+    let _guard = lock.lock().await;
+    let addr = state.orchestrator.ensure_started(&spec).await?;
+    state.activity.touch(user_id);
+    Ok(addr)
+}
+
+/// Stop the workspace (volume kept), checkpointing the activity time.
+pub async fn stop(state: &AppState, user_id: i32) -> Result<(), AppError> {
+    let lock = state.locks.lock_for(user_id);
+    let _guard = lock.lock().await;
+    state.orchestrator.stop(user_id).await?;
+    checkpoint_activity(state, user_id).await
+}
+
+/// Destroy the workspace and its volume, dropping the intent row.
+pub async fn destroy(state: &AppState, user_id: i32) -> Result<(), AppError> {
+    let lock = state.locks.lock_for(user_id);
+    let _guard = lock.lock().await;
+    state.orchestrator.destroy(user_id).await?;
+    workspace::Entity::delete_by_id(user_id)
+        .exec(&state.db)
+        .await?;
+    Ok(())
+}
+
+/// Write the in-memory activity time (when known) to the row so it survives
+/// restarts and shows up in the admin UI.
+async fn checkpoint_activity(state: &AppState, user_id: i32) -> Result<(), AppError> {
+    let Some(row) = workspace::Entity::find_by_id(user_id)
+        .one(&state.db)
+        .await?
+    else {
+        return Ok(());
+    };
+    let last_active = state
+        .activity
+        .get(user_id)
+        .map(|e| Utc::now() - chrono::Duration::from_std(e.last_seen.elapsed()).unwrap_or_default())
+        .unwrap_or_else(Utc::now);
+    let mut active: workspace::ActiveModel = row.into();
+    active.last_active_at = Set(Some(last_active));
+    active.updated_at = Set(Utc::now());
+    active.update(&state.db).await?;
+    Ok(())
+}
+
+/// Background loop stopping workspaces idle past the configured threshold.
+/// Workspaces found running without any in-memory activity (e.g. right after a
+/// CityHall restart) get a grace entry instead of an immediate stop.
+pub async fn idle_sweeper(state: AppState) {
+    let mut interval = tokio::time::interval(SWEEP_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        interval.tick().await;
+        if let Err(e) = sweep_once(&state).await {
+            tracing::warn!("idle sweep failed: {e}");
+        }
+    }
+}
+
+async fn sweep_once(state: &AppState) -> Result<(), AppError> {
+    let cfg = settings(&state.db).await?;
+    if !cfg.enabled {
+        return Ok(());
+    }
+    let idle_after = Duration::from_secs(cfg.idle_stop_minutes.max(1) as u64 * 60);
+
+    for row in workspace::Entity::find().all(&state.db).await? {
+        let user_id = row.user_id;
+        let entry = state.activity.get(user_id);
+        match entry {
+            None => {
+                // No in-memory record: if it is running (fresh restart), start
+                // the idle clock now rather than killing an active session.
+                if matches!(
+                    state.orchestrator.status(user_id).await,
+                    Ok(WorkspaceStatus::Running { .. })
+                ) {
+                    state.activity.touch(user_id);
+                }
+            }
+            Some(entry) if entry.active_websockets > 0 => {}
+            Some(entry) if entry.last_seen.elapsed() >= idle_after => {
+                let lock = state.locks.lock_for(user_id);
+                let _guard = lock.lock().await;
+                // Re-check under the lock: a proxy request may have just
+                // touched or restarted the workspace.
+                let still_idle = state
+                    .activity
+                    .get(user_id)
+                    .map(|e| e.active_websockets == 0 && e.last_seen.elapsed() >= idle_after)
+                    .unwrap_or(false);
+                if !still_idle {
+                    continue;
+                }
+                if let Ok(WorkspaceStatus::Running { .. }) =
+                    state.orchestrator.status(user_id).await
+                {
+                    tracing::info!(user_id, "stopping idle workspace");
+                    if let Err(e) = state.orchestrator.stop(user_id).await {
+                        tracing::warn!(user_id, "idle stop failed: {e}");
+                        continue;
+                    }
+                    checkpoint_activity(state, user_id).await?;
+                }
+            }
+            Some(_) => {
+                checkpoint_activity(state, user_id).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migration::Migrator;
+    use sea_orm::Database;
+    use sea_orm_migration::MigratorTrait;
+
+    async fn setup() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        Migrator::up(&db, None).await.unwrap();
+        db
+    }
+
+    fn cfg(default_version: Option<&str>) -> workspace_settings::Model {
+        workspace_settings::Model {
+            id: SETTINGS_ID,
+            enabled: true,
+            image_template: "cityhall/aoe:{version}".to_string(),
+            default_version: default_version.map(String::from),
+            idle_stop_minutes: 30,
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn settings_defaults_when_no_row() {
+        let db = setup().await;
+        let s = settings(&db).await.unwrap();
+        assert!(!s.enabled);
+        assert_eq!(s.image_template, "cityhall/aoe:{version}");
+        assert_eq!(s.idle_stop_minutes, 30);
+    }
+
+    #[tokio::test]
+    async fn get_or_create_is_idempotent() {
+        let db = setup().await;
+        let uid = crate::service::create(&db, "u", None, "password123", false, None)
+            .await
+            .unwrap()
+            .id;
+        let a = get_or_create(&db, uid).await.unwrap();
+        let b = get_or_create(&db, uid).await.unwrap();
+        assert_eq!(a.user_id, b.user_id);
+        assert_eq!(a.created_at, b.created_at);
+    }
+
+    #[tokio::test]
+    async fn spec_uses_pin_over_default() {
+        let db = setup().await;
+        let uid = crate::service::create(&db, "u", None, "password123", false, None)
+            .await
+            .unwrap()
+            .id;
+        let row = get_or_create(&db, uid).await.unwrap();
+        let spec = build_spec(&cfg(Some("v1.0.0")), &row).unwrap();
+        assert_eq!(spec.image, "cityhall/aoe:v1.0.0");
+
+        let mut active: workspace::ActiveModel = row.into();
+        active.pinned_version = Set(Some("v2.0.0".to_string()));
+        let row = active.update(&db).await.unwrap();
+        let spec = build_spec(&cfg(Some("v1.0.0")), &row).unwrap();
+        assert_eq!(spec.version, "v2.0.0");
+        assert_eq!(spec.image, "cityhall/aoe:v2.0.0");
+    }
+
+    #[tokio::test]
+    async fn spec_requires_some_version() {
+        let db = setup().await;
+        let uid = crate::service::create(&db, "u", None, "password123", false, None)
+            .await
+            .unwrap()
+            .id;
+        let row = get_or_create(&db, uid).await.unwrap();
+        assert!(build_spec(&cfg(None), &row).is_err());
+    }
+}

--- a/api/src/workspaces.rs
+++ b/api/src/workspaces.rs
@@ -21,7 +21,6 @@ pub async fn settings(db: &DatabaseConnection) -> Result<workspace_settings::Mod
         .await?
         .unwrap_or(workspace_settings::Model {
             id: SETTINGS_ID,
-            enabled: false,
             image_template: "cityhall/aoe:{version}".to_string(),
             default_version: None,
             idle_stop_minutes: 30,
@@ -30,7 +29,7 @@ pub async fn settings(db: &DatabaseConnection) -> Result<workspace_settings::Mod
 }
 
 /// On a first startup (no settings row saved yet), pre-fill the default
-/// version with the latest aoe release so enabling workspaces is one click.
+/// version with the latest aoe release so workspaces work out of the box.
 /// Best effort: offline or rate-limited lookups just log and skip; a saved
 /// row (even with no version) is never touched.
 pub async fn seed_default_version(db: &DatabaseConnection) -> Result<(), AppError> {
@@ -58,7 +57,6 @@ async fn apply_seeded_version(db: &DatabaseConnection, version: String) -> Resul
     let defaults = settings(db).await?;
     workspace_settings::ActiveModel {
         id: Set(SETTINGS_ID),
-        enabled: Set(defaults.enabled),
         image_template: Set(defaults.image_template),
         default_version: Set(Some(version)),
         idle_stop_minutes: Set(defaults.idle_stop_minutes),
@@ -150,11 +148,6 @@ impl From<OrchestratorError> for AppError {
 /// start endpoint calls it explicitly. Serialized per user against the sweeper.
 pub async fn ensure_started(state: &AppState, user_id: i32) -> Result<String, AppError> {
     let cfg = settings(&state.db).await?;
-    if !cfg.enabled {
-        return Err(AppError::WorkspaceUnavailable(
-            "workspaces are disabled; an admin can enable them in settings".to_string(),
-        ));
-    }
     let row = get_or_create(&state.db, user_id).await?;
     let spec = build_spec(&cfg, &row)?;
 
@@ -221,9 +214,6 @@ pub async fn idle_sweeper(state: AppState) {
 
 async fn sweep_once(state: &AppState) -> Result<(), AppError> {
     let cfg = settings(&state.db).await?;
-    if !cfg.enabled {
-        return Ok(());
-    }
     let idle_after = Duration::from_secs(cfg.idle_stop_minutes.max(1) as u64 * 60);
 
     for row in workspace::Entity::find().all(&state.db).await? {
@@ -289,7 +279,6 @@ mod tests {
     fn cfg(default_version: Option<&str>) -> workspace_settings::Model {
         workspace_settings::Model {
             id: SETTINGS_ID,
-            enabled: true,
             image_template: "cityhall/aoe:{version}".to_string(),
             default_version: default_version.map(String::from),
             idle_stop_minutes: 30,
@@ -305,7 +294,6 @@ mod tests {
             .unwrap();
         let s = settings(&db).await.unwrap();
         assert_eq!(s.default_version.as_deref(), Some("v9.9.9"));
-        assert!(!s.enabled);
     }
 
     #[tokio::test]
@@ -315,7 +303,6 @@ mod tests {
         // that choice alone (and must not hit the network to do so).
         workspace_settings::ActiveModel {
             id: Set(SETTINGS_ID),
-            enabled: Set(false),
             image_template: Set("cityhall/aoe:{version}".to_string()),
             default_version: Set(None),
             idle_stop_minutes: Set(30),
@@ -333,7 +320,6 @@ mod tests {
     async fn settings_defaults_when_no_row() {
         let db = setup().await;
         let s = settings(&db).await.unwrap();
-        assert!(!s.enabled);
         assert_eq!(s.image_template, "cityhall/aoe:{version}");
         assert_eq!(s.idle_stop_minutes, 30);
     }

--- a/api/src/workspaces.rs
+++ b/api/src/workspaces.rs
@@ -29,6 +29,72 @@ pub async fn settings(db: &DatabaseConnection) -> Result<workspace_settings::Mod
         }))
 }
 
+/// On a first startup (no settings row saved yet), pre-fill the default
+/// version with the latest aoe release so enabling workspaces is one click.
+/// Best effort: offline or rate-limited lookups just log and skip; a saved
+/// row (even with no version) is never touched.
+pub async fn seed_default_version(db: &DatabaseConnection) -> Result<(), AppError> {
+    if workspace_settings::Entity::find_by_id(SETTINGS_ID)
+        .one(db)
+        .await?
+        .is_some()
+    {
+        return Ok(());
+    }
+    let version = match fetch_latest_release().await {
+        Ok(tag) => tag,
+        Err(e) => {
+            tracing::warn!(
+                "could not resolve the latest aoe release for the default workspace version: {e}"
+            );
+            return Ok(());
+        }
+    };
+    tracing::info!(version = %version, "seeding workspace default version from the latest aoe release");
+    apply_seeded_version(db, version).await
+}
+
+async fn apply_seeded_version(db: &DatabaseConnection, version: String) -> Result<(), AppError> {
+    let defaults = settings(db).await?;
+    workspace_settings::ActiveModel {
+        id: Set(SETTINGS_ID),
+        enabled: Set(defaults.enabled),
+        image_template: Set(defaults.image_template),
+        default_version: Set(Some(version)),
+        idle_stop_minutes: Set(defaults.idle_stop_minutes),
+        updated_at: Set(Utc::now()),
+    }
+    .insert(db)
+    .await?;
+    Ok(())
+}
+
+/// The `tag_name` of the latest agent-of-empires GitHub release.
+async fn fetch_latest_release() -> Result<String, String> {
+    #[derive(serde::Deserialize)]
+    struct Release {
+        tag_name: String,
+    }
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let body = client
+        .get("https://api.github.com/repos/agent-of-empires/agent-of-empires/releases/latest")
+        // GitHub's API rejects requests without a User-Agent.
+        .header("User-Agent", "cityhall")
+        .send()
+        .await
+        .map_err(|e| e.to_string())?
+        .error_for_status()
+        .map_err(|e| e.to_string())?
+        .text()
+        .await
+        .map_err(|e| e.to_string())?;
+    let release: Release = serde_json::from_str(&body).map_err(|e| e.to_string())?;
+    Ok(release.tag_name)
+}
+
 /// The user's workspace intent row, created on first use.
 pub async fn get_or_create(
     db: &DatabaseConnection,
@@ -229,6 +295,38 @@ mod tests {
             idle_stop_minutes: 30,
             updated_at: Utc::now(),
         }
+    }
+
+    #[tokio::test]
+    async fn seeded_version_fills_a_fresh_install() {
+        let db = setup().await;
+        apply_seeded_version(&db, "v9.9.9".to_string())
+            .await
+            .unwrap();
+        let s = settings(&db).await.unwrap();
+        assert_eq!(s.default_version.as_deref(), Some("v9.9.9"));
+        assert!(!s.enabled);
+    }
+
+    #[tokio::test]
+    async fn seeding_never_touches_a_saved_row() {
+        let db = setup().await;
+        // Operator saved settings without a version; the seeder must leave
+        // that choice alone (and must not hit the network to do so).
+        workspace_settings::ActiveModel {
+            id: Set(SETTINGS_ID),
+            enabled: Set(false),
+            image_template: Set("cityhall/aoe:{version}".to_string()),
+            default_version: Set(None),
+            idle_stop_minutes: Set(30),
+            updated_at: Set(Utc::now()),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+
+        seed_default_version(&db).await.unwrap();
+        assert_eq!(settings(&db).await.unwrap().default_version, None);
     }
 
     #[tokio::test]

--- a/deploy/aoe-image/Dockerfile
+++ b/deploy/aoe-image/Dockerfile
@@ -26,8 +26,10 @@ RUN test -n "$AOE_VERSION" || (echo "AOE_VERSION build arg is required" && exit 
          arm64) AOE_ARCH=arm64 ;; \
          *) echo "unsupported arch: $TARGETARCH" && exit 1 ;; \
        esac \
+    # The tarball contains a single arch-suffixed binary (aoe-linux-<arch>).
     && curl -fsSL "https://github.com/agent-of-empires/agent-of-empires/releases/download/${AOE_VERSION}/aoe-linux-${AOE_ARCH}.tar.gz" \
        | tar -xz -C /usr/local/bin \
+    && mv "/usr/local/bin/aoe-linux-${AOE_ARCH}" /usr/local/bin/aoe \
     && chmod +x /usr/local/bin/aoe
 
 RUN useradd -m -d /home/aoe aoe \

--- a/deploy/aoe-image/Dockerfile
+++ b/deploy/aoe-image/Dockerfile
@@ -1,0 +1,42 @@
+# Reference image for CityHall workspaces: the aoe binary serving its web
+# dashboard, one container per user. Build one image per aoe version:
+#
+#   docker build --build-arg AOE_VERSION=v0.5.0 -t cityhall/aoe:v0.5.0 deploy/aoe-image/
+#
+# The tag must match the workspace settings image template (default
+# `cityhall/aoe:{version}`) rendered with the version users are pinned to.
+# CityHall starts containers from this image with:
+#   aoe serve --host 0.0.0.0 --port 8080 --auth none --behind-proxy
+# and mounts a per-user volume at /home/aoe/.config/agent-of-empires.
+
+FROM debian:bookworm-slim
+
+# TARGETARCH is set automatically by buildx; plain `docker build` falls back
+# to the build host's architecture.
+ARG AOE_VERSION
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl git tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN test -n "$AOE_VERSION" || (echo "AOE_VERSION build arg is required" && exit 1) \
+    && case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+         amd64) AOE_ARCH=amd64 ;; \
+         arm64) AOE_ARCH=arm64 ;; \
+         *) echo "unsupported arch: $TARGETARCH" && exit 1 ;; \
+       esac \
+    && curl -fsSL "https://github.com/agent-of-empires/agent-of-empires/releases/download/${AOE_VERSION}/aoe-linux-${AOE_ARCH}.tar.gz" \
+       | tar -xz -C /usr/local/bin \
+    && chmod +x /usr/local/bin/aoe
+
+RUN useradd -m -d /home/aoe aoe \
+    # Pre-create the app dir so the named volume inherits aoe's ownership on
+    # first mount.
+    && mkdir -p /home/aoe/.config/agent-of-empires \
+    && chown -R aoe:aoe /home/aoe
+
+USER aoe
+ENV HOME=/home/aoe
+
+EXPOSE 8080

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,9 +25,10 @@ Every user has a role, and a role holds a set of permission keys (the wildcard
 `*` grants all). Endpoints require a specific permission; a caller lacking it
 gets `403 Forbidden` with `{"error":"insufficient permissions"}`. The current
 keys are `users.read`, `users.write`, `roles.read`, `roles.write`,
-`settings.read`, and `settings.write`. `GET /api/auth/me` returns the caller's
-effective permission list so a client can gate its UI. Built-in roles are
-`admin` (all permissions) and `member` (`users.read`).
+`settings.read`, `settings.write`, `workspaces.use`, `workspaces.read`, and
+`workspaces.write`. `GET /api/auth/me` returns the caller's effective
+permission list so a client can gate its UI. Built-in roles are `admin` (all
+permissions) and `member` (`users.read`, `workspaces.use`).
 
 ## Errors
 
@@ -414,3 +415,89 @@ Requires `settings.write`. Updates the self-signup configuration (same shape as
 unknown `signup_default_role_id` returns `400`. Enabling signup while SMTP is
 unconfigured returns `400` (verification email cannot be sent). Returns the
 updated settings.
+
+### `GET /api/workspaces`
+
+Requires `workspaces.read`. Returns every user with their workspace state (see
+[Workspaces](workspaces.md)). `status` is `not_created`, `stopped`, `running`,
+or `unknown` (runtime unreachable); `effective_version` is the pin or the
+default.
+
+```json
+[
+  {
+    "user_id": 2,
+    "username": "bob",
+    "status": "running",
+    "pinned_version": null,
+    "effective_version": "v0.5.0",
+    "last_active_at": "2026-07-15T09:20:50Z"
+  }
+]
+```
+
+### `GET /api/workspaces/me`
+
+Requires `workspaces.use`. The caller's own workspace plus the origin browsers
+use to reach the workspace proxy:
+
+```json
+{
+  "enabled": true,
+  "status": "stopped",
+  "pinned_version": null,
+  "effective_version": "v0.5.0",
+  "proxy_origin": "http://127.0.0.1:3001"
+}
+```
+
+### `POST /api/workspaces/{user_id}/start`
+
+Requires `workspaces.write`. Starts (or resumes) the user's workspace. Returns
+`503` with a descriptive error when the runtime or image is unavailable.
+
+### `POST /api/workspaces/{user_id}/stop`
+
+Requires `workspaces.write`. Stops the workspace, keeping its data volume.
+
+### `DELETE /api/workspaces/{user_id}`
+
+Requires `workspaces.write`. Destroys the workspace AND its data volume.
+Returns `{ "destroyed": true }`.
+
+### `PATCH /api/workspaces/{user_id}`
+
+Requires `workspaces.write`. Pins the served aoe version (`null` or empty
+unpins, following the default). A running workspace is recreated with the new
+image on its next start or proxied request; its volume is kept.
+
+```json
+{ "pinned_version": "v0.5.1" }
+```
+
+### `PATCH /api/workspaces`
+
+Requires `workspaces.write`. Grouped pin: same as above for several users in
+one call.
+
+```json
+{ "user_ids": [2, 3], "pinned_version": "v0.5.1" }
+```
+
+### `GET /api/settings/workspaces`
+
+Requires `settings.read`.
+
+```json
+{
+  "enabled": false,
+  "image_template": "cityhall/aoe:{version}",
+  "default_version": "v0.5.0",
+  "idle_stop_minutes": 30
+}
+```
+
+### `PUT /api/settings/workspaces`
+
+Requires `settings.write`. Same shape as `GET`. Enabling workspaces without a
+default version returns `400`; `idle_stop_minutes` must be at least 1.

--- a/docs/api.md
+++ b/docs/api.md
@@ -443,7 +443,6 @@ use to reach the workspace proxy:
 
 ```json
 {
-  "enabled": true,
   "status": "stopped",
   "pinned_version": null,
   "effective_version": "v0.5.0",
@@ -490,7 +489,6 @@ Requires `settings.read`.
 
 ```json
 {
-  "enabled": false,
   "image_template": "cityhall/aoe:{version}",
   "default_version": "v0.5.0",
   "idle_stop_minutes": 30
@@ -499,5 +497,5 @@ Requires `settings.read`.
 
 ### `PUT /api/settings/workspaces`
 
-Requires `settings.write`. Same shape as `GET`. Enabling workspaces without a
-default version returns `400`; `idle_stop_minutes` must be at least 1.
+Requires `settings.write`. Same shape as `GET`. `image_template` is required;
+`idle_stop_minutes` must be at least 1.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,9 @@ Docker, Compose, or Kubernetes deployment without a config file.
 | `OIDC_CLIENT_SECRET` | _(unset)_                  | OIDC client secret (omit for public clients).       |
 | `OIDC_SCOPES`   | `openid email profile`           | Space-separated scopes to request.                  |
 | `OIDC_ALLOWED_DOMAINS` | _(any)_                   | Comma-separated email domains allowed to auto-provision. |
+| `WORKSPACE_PROXY_BIND_ADDR` | `127.0.0.1:3001`     | Workspace proxy listener (see [Workspaces](workspaces.md)). |
+| `WORKSPACE_PROXY_PUBLIC_ORIGIN` | _(derived)_      | Public origin of the workspace proxy behind a reverse proxy. |
+| `CONTAINER_CLI` | `docker`                         | Container CLI used to manage workspaces (e.g. `podman`). |
 
 ## Database
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ control plane builds on:
 ## Next steps
 
 - [Quick start](quick-start.md): run it and sign in.
+- [Workspaces](workspaces.md): per-user aoe instances spawned and proxied by CityHall.
 - [Configuration](configuration.md): database, bind address, logging, and email.
 - [Deployment](deployment.md): Docker, Compose, Kubernetes, VPS, HTTPS, and databases.
 - [CLI reference](cli.md): manage users from the terminal.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -33,7 +33,8 @@ version changes.
    ```
 
 2. In **Settings → Workspaces**, set the default version (e.g. `v0.5.0`) and
-   enable workspaces.
+   enable workspaces. On a first startup the default version is pre-filled
+   with the latest aoe release (skipped when offline; the field stays empty).
 
 Members hold the `workspaces.use` permission by default and can open their own
 workspace. `workspaces.read` / `workspaces.write` gate the admin Workspaces

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,0 +1,75 @@
+# Workspaces
+
+A workspace is one long-lived [aoe](https://github.com/agent-of-empires/agent-of-empires)
+instance per user, spawned and managed by CityHall (docker containers today;
+the orchestration seam is backend-agnostic). Each workspace has a persistent
+data volume, so aoe sessions and configuration survive stops, restarts, and
+version changes.
+
+## How it works
+
+- **Request-driven start.** Opening the workspace (the "Open workspace" link,
+  or any request to the workspace proxy) starts the container if needed and
+  resumes it if stopped. There is no manual start step for users.
+- **Idle stop.** A workspace with no traffic for the configured idle window
+  (default 30 minutes) is stopped automatically. Open WebSocket connections
+  (live terminals) count as activity, so an open dashboard is never cut off.
+  Stopping keeps the volume; the next request resumes with all data intact.
+- **Destroy** (admin action) removes the container AND its volume. This
+  deletes the user's aoe data permanently.
+- **Versions.** Admins set a default aoe version and can pin individual users
+  (or a selected group) to a specific version. A version change recreates the
+  container on its next start, keeping the volume. The image used is the
+  settings' image template with `{version}` substituted, e.g.
+  `cityhall/aoe:v0.5.0`.
+
+## Enabling workspaces
+
+1. Build the workspace image for the version you want to serve (no official
+   aoe server image is published yet):
+
+   ```sh
+   docker build --build-arg AOE_VERSION=v0.5.0 -t cityhall/aoe:v0.5.0 deploy/aoe-image/
+   ```
+
+2. In **Settings → Workspaces**, set the default version (e.g. `v0.5.0`) and
+   enable workspaces.
+
+Members hold the `workspaces.use` permission by default and can open their own
+workspace. `workspaces.read` / `workspaces.write` gate the admin Workspaces
+page and its actions.
+
+## The workspace proxy
+
+Workspaces are served through a dedicated listener (default
+`127.0.0.1:3001`), separate from the main CityHall origin, because the aoe
+dashboard owns root-absolute paths. Every proxied request is authenticated
+with the regular CityHall session cookie; the container itself runs
+`aoe serve --auth=none --behind-proxy` and is only reachable through a
+loopback-published port, so CityHall is the sole auth boundary. In development
+nothing needs configuring: the cookie set by `127.0.0.1:3000` is also sent to
+`127.0.0.1:3001` (cookies ignore ports).
+
+For production, expose the proxy listener through your reverse proxy as either
+a subdomain or a second external port, and set `WORKSPACE_PROXY_PUBLIC_ORIGIN`
+so the "Open workspace" link points at the public address. A subdomain needs
+the session cookie to be visible there; today the cookie is host-only, so use
+the same hostname with a second port, or terminate both origins on the same
+host. WebSocket upgrade forwarding must be enabled on the external proxy.
+
+| Variable | Default | Purpose |
+| -------- | ------- | ------- |
+| `WORKSPACE_PROXY_BIND_ADDR` | `127.0.0.1:3001` | Address of the workspace proxy listener. |
+| `WORKSPACE_PROXY_PUBLIC_ORIGIN` | _(derived)_ | Public origin browsers use to reach the proxy. |
+| `CONTAINER_CLI` | `docker` | Container CLI binary (e.g. `podman`). |
+
+## Current limitations
+
+- CityHall must run natively on the docker host (the backend dials
+  loopback-published ports). CityHall-in-docker/compose/kubernetes topologies
+  and non-docker backends are tracked in
+  [#18](https://github.com/agent-of-empires/cityhall/issues/18).
+- Workspace images are operator-built ([#17](https://github.com/agent-of-empires/cityhall/issues/17)
+  tracks auto-pull/build).
+- Agent credentials are not forwarded into workspaces yet
+  ([#16](https://github.com/agent-of-empires/cityhall/issues/16)).

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -23,18 +23,20 @@ version changes.
   settings' image template with `{version}` substituted, e.g.
   `cityhall/aoe:v0.5.0`.
 
-## Enabling workspaces
+## Setup
 
-1. Build the workspace image for the version you want to serve (no official
-   aoe server image is published yet):
+Workspaces are always on; the only required setup is the image. Build the
+workspace image for the version you want to serve (no official aoe server
+image is published yet):
 
-   ```sh
-   docker build --build-arg AOE_VERSION=v0.5.0 -t cityhall/aoe:v0.5.0 deploy/aoe-image/
-   ```
+```sh
+docker build --build-arg AOE_VERSION=v0.5.0 -t cityhall/aoe:v0.5.0 deploy/aoe-image/
+```
 
-2. In **Settings → Workspaces**, set the default version (e.g. `v0.5.0`) and
-   enable workspaces. On a first startup the default version is pre-filled
-   with the latest aoe release (skipped when offline; the field stays empty).
+On a first startup the default version is pre-filled with the latest aoe
+release (skipped when offline); adjust it under **Settings → Workspaces** if
+needed. Starting a workspace with no default version set, or with an image
+that is not built, fails with a descriptive error.
 
 Members hold the `workspaces.use` permission by default and can open their own
 workspace. `workspaces.read` / `workspaces.write` gate the admin Workspaces

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { ForgotPasswordPage } from "./components/ForgotPasswordPage";
 import { ResetPasswordPage } from "./components/ResetPasswordPage";
 import { RegisterPage } from "./components/RegisterPage";
 import { VerifyEmailPage } from "./components/VerifyEmailPage";
+import { WorkspacesPage } from "./components/WorkspacesPage";
 
 export function App() {
   const [me, setMe] = useState<Me | null>(null);
@@ -78,6 +79,18 @@ export function App() {
             <Navigate to="/change-password" replace />
           ) : (
             <RolesPage me={me} onLogout={refresh} />
+          )
+        }
+      />
+      <Route
+        path="/workspaces"
+        element={
+          !me ? (
+            <Navigate to="/login" replace />
+          ) : me.must_change_password ? (
+            <Navigate to="/change-password" replace />
+          ) : (
+            <WorkspacesPage me={me} onLogout={refresh} />
           )
         }
       />

--- a/web/src/components/SettingsPage.tsx
+++ b/web/src/components/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { api, ApiError, type Me, type SmtpSettings } from "../lib/api";
 import { TopBar } from "./TopBar";
 import { OidcSettingsSection } from "./OidcSettings";
 import { SignupSettingsSection } from "./SignupSettings";
+import { WorkspaceSettingsSection } from "./WorkspaceSettings";
 import { Button, ErrorText, Field, Input, Select } from "./ui";
 
 export function SettingsPage({ me, onLogout }: { me: Me; onLogout: () => Promise<void> }) {
@@ -245,6 +246,8 @@ export function SettingsPage({ me, onLogout }: { me: Me; onLogout: () => Promise
         <OidcSettingsSection />
 
         <SignupSettingsSection />
+
+        <WorkspaceSettingsSection />
       </main>
     </div>
   );

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -12,15 +12,14 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
   );
 
 export function TopBar({ me, onLogout }: { me: Me; onLogout: () => Promise<void> }) {
-  // The user's workspace origin; only fetched when they may use one, only
-  // rendered when workspaces are enabled.
+  // The user's workspace origin; only fetched when they may use one.
   const [workspaceOrigin, setWorkspaceOrigin] = useState<string | null>(null);
 
   useEffect(() => {
     if (!can(me, "workspaces.use")) return;
     api
       .myWorkspace()
-      .then((w) => setWorkspaceOrigin(w.enabled ? w.proxy_origin : null))
+      .then((w) => setWorkspaceOrigin(w.proxy_origin))
       .catch(() => {});
   }, [me]);
 

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
-import { LogOut, Settings, Shield, Users } from "lucide-react";
+import { Boxes, ExternalLink, LogOut, Settings, Shield, Users } from "lucide-react";
+import { useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
 import { api, can, type Me } from "../lib/api";
 import { Button } from "./ui";
@@ -11,6 +12,18 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
   );
 
 export function TopBar({ me, onLogout }: { me: Me; onLogout: () => Promise<void> }) {
+  // The user's workspace origin; only fetched when they may use one, only
+  // rendered when workspaces are enabled.
+  const [workspaceOrigin, setWorkspaceOrigin] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!can(me, "workspaces.use")) return;
+    api
+      .myWorkspace()
+      .then((w) => setWorkspaceOrigin(w.enabled ? w.proxy_origin : null))
+      .catch(() => {});
+  }, [me]);
+
   async function logout() {
     await api.logout();
     await onLogout();
@@ -31,6 +44,12 @@ export function TopBar({ me, onLogout }: { me: Me; onLogout: () => Promise<void>
               Roles
             </NavLink>
           )}
+          {can(me, "workspaces.read") && (
+            <NavLink to="/workspaces" className={navLinkClass}>
+              <Boxes size={14} />
+              Workspaces
+            </NavLink>
+          )}
           {can(me, "settings.read") && (
             <NavLink to="/settings" className={navLinkClass}>
               <Settings size={14} />
@@ -40,6 +59,17 @@ export function TopBar({ me, onLogout }: { me: Me; onLogout: () => Promise<void>
         </nav>
       </div>
       <div className="flex items-center gap-3">
+        {workspaceOrigin && (
+          <a
+            href={workspaceOrigin}
+            target="_blank"
+            rel="noreferrer"
+            className="flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-text-secondary transition-colors hover:text-text-primary"
+          >
+            <ExternalLink size={14} />
+            Open workspace
+          </a>
+        )}
         <span className="text-sm text-text-secondary">{me.username}</span>
         <Button variant="ghost" onClick={logout} className="flex items-center gap-1.5">
           <LogOut size={14} />

--- a/web/src/components/WorkspaceSettings.tsx
+++ b/web/src/components/WorkspaceSettings.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, ApiError, type WorkspaceSettings } from "../lib/api";
+import { Button, ErrorText, Field, Input } from "./ui";
+
+export function WorkspaceSettingsSection() {
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [enabled, setEnabled] = useState(false);
+  const [imageTemplate, setImageTemplate] = useState("");
+  const [defaultVersion, setDefaultVersion] = useState("");
+  const [idleStopMinutes, setIdleStopMinutes] = useState(30);
+
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const apply = useCallback((s: WorkspaceSettings) => {
+    setEnabled(s.enabled);
+    setImageTemplate(s.image_template);
+    setDefaultVersion(s.default_version ?? "");
+    setIdleStopMinutes(s.idle_stop_minutes);
+  }, []);
+
+  const load = useCallback(async () => {
+    try {
+      apply(await api.getWorkspaceSettings());
+      setLoadError(null);
+    } catch (e) {
+      setLoadError(e instanceof ApiError ? e.message : "could not load workspace settings");
+    }
+  }, [apply]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function save(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setSaveError(null);
+    setSaved(false);
+    try {
+      apply(
+        await api.updateWorkspaceSettings({
+          enabled,
+          image_template: imageTemplate,
+          default_version: defaultVersion.trim() || null,
+          idle_stop_minutes: idleStopMinutes,
+        }),
+      );
+      setSaved(true);
+    } catch (err) {
+      setSaveError(err instanceof ApiError ? err.message : "could not save workspace settings");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <h2 className="mt-4 font-mono text-xs uppercase tracking-wider text-text-muted">Workspaces</h2>
+
+      {loadError && <ErrorText>{loadError}</ErrorText>}
+
+      <form onSubmit={save} className="space-y-4 rounded-lg border border-surface-700 p-5">
+        <label className="flex items-center gap-2 text-sm text-text-primary">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+            className="h-4 w-4 accent-brand-500"
+          />
+          Enable per-user aoe workspaces
+        </label>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <Field label="Image template">
+            <Input
+              value={imageTemplate}
+              onChange={(e) => setImageTemplate(e.target.value)}
+              placeholder="cityhall/aoe:{version}"
+            />
+          </Field>
+          <Field label="Default version">
+            <Input value={defaultVersion} onChange={(e) => setDefaultVersion(e.target.value)} placeholder="v0.1.0" />
+          </Field>
+          <Field label="Idle stop (minutes)">
+            <Input
+              type="number"
+              value={idleStopMinutes}
+              onChange={(e) => setIdleStopMinutes(Number(e.target.value))}
+              min={1}
+            />
+          </Field>
+        </div>
+
+        <p className="text-sm text-text-secondary">
+          The image for a user is the template with <code className="text-text-primary">{"{version}"}</code> replaced by
+          their pinned version (or the default). Idle workspaces are stopped automatically; their data volume is kept.
+        </p>
+
+        {saveError && <ErrorText>{saveError}</ErrorText>}
+        {saved && <p className="text-sm text-status-running">Settings saved.</p>}
+
+        <div className="flex justify-end">
+          <Button type="submit" variant="primary" disabled={saving}>
+            {saving ? "Saving..." : "Save settings"}
+          </Button>
+        </div>
+      </form>
+    </>
+  );
+}

--- a/web/src/components/WorkspaceSettings.tsx
+++ b/web/src/components/WorkspaceSettings.tsx
@@ -5,7 +5,6 @@ import { Button, ErrorText, Field, Input } from "./ui";
 export function WorkspaceSettingsSection() {
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  const [enabled, setEnabled] = useState(false);
   const [imageTemplate, setImageTemplate] = useState("");
   const [defaultVersion, setDefaultVersion] = useState("");
   const [idleStopMinutes, setIdleStopMinutes] = useState(30);
@@ -15,7 +14,6 @@ export function WorkspaceSettingsSection() {
   const [saved, setSaved] = useState(false);
 
   const apply = useCallback((s: WorkspaceSettings) => {
-    setEnabled(s.enabled);
     setImageTemplate(s.image_template);
     setDefaultVersion(s.default_version ?? "");
     setIdleStopMinutes(s.idle_stop_minutes);
@@ -42,7 +40,6 @@ export function WorkspaceSettingsSection() {
     try {
       apply(
         await api.updateWorkspaceSettings({
-          enabled,
           image_template: imageTemplate,
           default_version: defaultVersion.trim() || null,
           idle_stop_minutes: idleStopMinutes,
@@ -63,16 +60,6 @@ export function WorkspaceSettingsSection() {
       {loadError && <ErrorText>{loadError}</ErrorText>}
 
       <form onSubmit={save} className="space-y-4 rounded-lg border border-surface-700 p-5">
-        <label className="flex items-center gap-2 text-sm text-text-primary">
-          <input
-            type="checkbox"
-            checked={enabled}
-            onChange={(e) => setEnabled(e.target.checked)}
-            className="h-4 w-4 accent-brand-500"
-          />
-          Enable per-user aoe workspaces
-        </label>
-
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <Field label="Image template">
             <Input

--- a/web/src/components/WorkspacesPage.tsx
+++ b/web/src/components/WorkspacesPage.tsx
@@ -21,6 +21,7 @@ const STATUS_LABELS: Record<WorkspaceItem["status"], string> = {
 export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promise<void> }) {
   const canWrite = can(me, "workspaces.write");
   const [items, setItems] = useState<WorkspaceItem[]>([]);
+  const [proxyOrigin, setProxyOrigin] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [version, setVersion] = useState("");
@@ -37,6 +38,10 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
 
   useEffect(() => {
     void load();
+    api
+      .myWorkspace()
+      .then((w) => setProxyOrigin(w.proxy_origin))
+      .catch(() => {});
   }, [load]);
 
   function toggle(userId: number) {
@@ -97,6 +102,17 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
         </div>
 
         {error && <p className="text-sm text-status-error">{error}</p>}
+
+        {proxyOrigin && (
+          <div className="rounded-md border border-surface-700 bg-surface-850 px-4 py-3 text-sm text-text-secondary">
+            All workspaces are served at{" "}
+            <a href={proxyOrigin} target="_blank" rel="noreferrer" className="text-text-primary underline">
+              {proxyOrigin}
+            </a>
+            ; each signed-in user reaches their own workspace there. Containers listen on internal loopback ports
+            managed automatically.
+          </div>
+        )}
 
         <div className="overflow-hidden rounded-lg border border-surface-700">
           <table className="w-full text-sm">

--- a/web/src/components/WorkspacesPage.tsx
+++ b/web/src/components/WorkspacesPage.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useState } from "react";
+import { Play, Square, Trash2 } from "lucide-react";
+import { api, ApiError, can, type Me, type WorkspaceItem } from "../lib/api";
+import { TopBar } from "./TopBar";
+import { Button, Input } from "./ui";
+
+const STATUS_STYLES: Record<WorkspaceItem["status"], string> = {
+  running: "text-status-running",
+  stopped: "text-status-waiting",
+  not_created: "text-text-muted",
+  unknown: "text-status-error",
+};
+
+const STATUS_LABELS: Record<WorkspaceItem["status"], string> = {
+  running: "running",
+  stopped: "stopped",
+  not_created: "not created",
+  unknown: "unknown",
+};
+
+export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promise<void> }) {
+  const canWrite = can(me, "workspaces.write");
+  const [items, setItems] = useState<WorkspaceItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [version, setVersion] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setItems(await api.listWorkspaces());
+      setError(null);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "could not load workspaces");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function toggle(userId: number) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  }
+
+  async function run(action: () => Promise<unknown>, failure: string) {
+    setBusy(true);
+    try {
+      await action();
+      setError(null);
+      await load();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : failure);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function applyVersion() {
+    const ids = [...selected];
+    await run(() => api.bulkSetWorkspaceVersion(ids, version.trim() || null), "could not set version");
+    setSelected(new Set());
+    setVersion("");
+  }
+
+  async function destroy(item: WorkspaceItem) {
+    if (!confirm(`Destroy ${item.username}'s workspace? This permanently deletes its data volume.`)) {
+      return;
+    }
+    await run(() => api.destroyWorkspace(item.user_id), "could not destroy workspace");
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <TopBar me={me} onLogout={onLogout} />
+      <main className="mx-auto w-full max-w-4xl flex-1 space-y-4 overflow-auto p-6">
+        <div className="flex items-center justify-between">
+          <h2 className="font-mono text-xs uppercase tracking-wider text-text-muted">Workspaces</h2>
+          {canWrite && (
+            <div className="flex items-end gap-2">
+              <Input
+                value={version}
+                onChange={(e) => setVersion(e.target.value)}
+                placeholder="version, empty = default"
+                className="w-52"
+              />
+              <Button variant="primary" disabled={busy || selected.size === 0} onClick={applyVersion}>
+                Set version ({selected.size})
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {error && <p className="text-sm text-status-error">{error}</p>}
+
+        <div className="overflow-hidden rounded-lg border border-surface-700">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-surface-700 bg-surface-850 text-left font-mono text-xs uppercase tracking-wider text-text-muted">
+                {canWrite && <th className="w-8 px-4 py-2.5" />}
+                <th className="px-4 py-2.5 font-medium">User</th>
+                <th className="px-4 py-2.5 font-medium">Status</th>
+                <th className="px-4 py-2.5 font-medium">Version</th>
+                <th className="px-4 py-2.5 font-medium">Last active</th>
+                {canWrite && <th className="px-4 py-2.5 text-right font-medium">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => (
+                <tr key={item.user_id} className="border-b border-surface-800 last:border-0">
+                  {canWrite && (
+                    <td className="px-4 py-2.5">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(item.user_id)}
+                        onChange={() => toggle(item.user_id)}
+                        className="h-4 w-4 accent-brand-500"
+                      />
+                    </td>
+                  )}
+                  <td className="px-4 py-2.5 text-text-primary">{item.username}</td>
+                  <td className={`px-4 py-2.5 ${STATUS_STYLES[item.status]}`}>{STATUS_LABELS[item.status]}</td>
+                  <td className="px-4 py-2.5 text-text-secondary">
+                    {item.pinned_version ?? (item.effective_version ? `default (${item.effective_version})` : "-")}
+                  </td>
+                  <td className="px-4 py-2.5 text-text-secondary">
+                    {item.last_active_at ? new Date(item.last_active_at).toLocaleString() : "-"}
+                  </td>
+                  {canWrite && (
+                    <td className="px-4 py-2.5">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          disabled={busy || item.status === "running"}
+                          onClick={() => run(() => api.startWorkspace(item.user_id), "could not start workspace")}
+                          title="Start"
+                        >
+                          <Play size={14} />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          disabled={busy || item.status !== "running"}
+                          onClick={() => run(() => api.stopWorkspace(item.user_id), "could not stop workspace")}
+                          title="Stop (keeps data)"
+                        >
+                          <Square size={14} />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          disabled={busy || item.status === "not_created"}
+                          onClick={() => destroy(item)}
+                          title="Destroy (deletes data)"
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              ))}
+              {items.length === 0 && (
+                <tr>
+                  <td colSpan={canWrite ? 6 : 4} className="px-4 py-6 text-center text-text-muted">
+                    No users.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -107,6 +107,30 @@ export interface OidcUpdate {
   allowed_domains: string;
 }
 
+export interface WorkspaceItem {
+  user_id: number;
+  username: string;
+  status: "not_created" | "stopped" | "running" | "unknown";
+  pinned_version: string | null;
+  effective_version: string | null;
+  last_active_at: string | null;
+}
+
+export interface MyWorkspace {
+  enabled: boolean;
+  status: "not_created" | "stopped" | "running" | "unknown";
+  pinned_version: string | null;
+  effective_version: string | null;
+  proxy_origin: string;
+}
+
+export interface WorkspaceSettings {
+  enabled: boolean;
+  image_template: string;
+  default_version: string | null;
+  idle_stop_minutes: number;
+}
+
 export class ApiError extends Error {
   status: number;
   constructor(status: number, message: string) {
@@ -215,6 +239,27 @@ export const api = {
   getOidcSettings: () => request<OidcSettings>("/settings/oidc"),
   updateOidcSettings: (patch: OidcUpdate) =>
     request<OidcSettings>("/settings/oidc", {
+      method: "PUT",
+      body: JSON.stringify(patch),
+    }),
+  listWorkspaces: () => request<WorkspaceItem[]>("/workspaces"),
+  myWorkspace: () => request<MyWorkspace>("/workspaces/me"),
+  startWorkspace: (userId: number) => request<{ status: string }>(`/workspaces/${userId}/start`, { method: "POST" }),
+  stopWorkspace: (userId: number) => request<{ status: string }>(`/workspaces/${userId}/stop`, { method: "POST" }),
+  destroyWorkspace: (userId: number) => request<{ destroyed: boolean }>(`/workspaces/${userId}`, { method: "DELETE" }),
+  setWorkspaceVersion: (userId: number, pinnedVersion: string | null) =>
+    request<{ pinned_version: string | null }>(`/workspaces/${userId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ pinned_version: pinnedVersion }),
+    }),
+  bulkSetWorkspaceVersion: (userIds: number[], pinnedVersion: string | null) =>
+    request<{ pinned_version: string | null }>("/workspaces", {
+      method: "PATCH",
+      body: JSON.stringify({ user_ids: userIds, pinned_version: pinnedVersion }),
+    }),
+  getWorkspaceSettings: () => request<WorkspaceSettings>("/settings/workspaces"),
+  updateWorkspaceSettings: (patch: WorkspaceSettings) =>
+    request<WorkspaceSettings>("/settings/workspaces", {
       method: "PUT",
       body: JSON.stringify(patch),
     }),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -117,7 +117,6 @@ export interface WorkspaceItem {
 }
 
 export interface MyWorkspace {
-  enabled: boolean;
   status: "not_created" | "stopped" | "running" | "unknown";
   pinned_version: string | null;
   effective_version: string | null;
@@ -125,7 +124,6 @@ export interface MyWorkspace {
 }
 
 export interface WorkspaceSettings {
-  enabled: boolean;
   image_template: string;
   default_version: string | null;
   idle_stop_minutes: number;

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -20,6 +20,8 @@ const PAGES = [
     description: "CityHall: the self-hostable control-plane server for Agent of Empires." },
   { source: "docs/quick-start.md", dest: "docs/quick-start.md", title: "Quick Start",
     description: "Run CityHall, sign in, and manage users." },
+  { source: "docs/workspaces.md", dest: "docs/workspaces.md", title: "Workspaces",
+    description: "Per-user aoe instances spawned, versioned, and proxied by CityHall." },
   { source: "docs/configuration.md", dest: "docs/configuration.md", title: "Configuration",
     description: "Database, bind address, logging, email/SMTP, SSO, and self-signup." },
   { source: "docs/deployment.md", dest: "docs/deployment.md", title: "Deployment",
@@ -36,6 +38,7 @@ const PAGES = [
 const URL_MAP = {
   "docs/index.md": "/docs/",
   "docs/quick-start.md": "/docs/quick-start/",
+  "docs/workspaces.md": "/docs/workspaces/",
   "docs/configuration.md": "/docs/configuration/",
   "docs/deployment.md": "/docs/deployment/",
   "docs/cli.md": "/docs/cli/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -22,6 +22,7 @@ export const docsNav: NavSection[] = [
   {
     title: "Operate",
     items: [
+      { title: "Workspaces", href: "/docs/workspaces/" },
       { title: "Configuration", href: "/docs/configuration/" },
       { title: "Deployment", href: "/docs/deployment/" },
       { title: "CLI Reference", href: "/docs/cli/" },


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

CityHall can now spawn and manage one long-lived aoe instance per user, called a **workspace**, and reverse-proxy its web dashboard behind the CityHall session.

The core is a backend-agnostic `Orchestrator` seam (`ensure_started` / `stop` / `destroy` / `status`) with a first docker backend that shells out to the container CLI (`docker`, or `podman` via `CONTAINER_CLI`). Each workspace is a container with a named data volume mounted at the aoe app dir, published on a loopback-only ephemeral port. Stopping keeps the volume; destroying removes it; a version change recreates the container while the volume survives, so aoe sessions and config persist across all of it.

The workspace proxy is a second listener (default `127.0.0.1:3001`): the aoe dashboard owns root-absolute paths, so it gets its own origin instead of a path prefix. The regular CityHall session cookie authenticates there with zero configuration in dev (cookies ignore ports), and every request is gated on the new `workspaces.use` permission. Requests start the workspace on demand; an idle sweeper stops workspaces with no traffic past a configurable threshold, with open WebSocket tunnels holding a lease so live terminals are never cut. WebSockets are bridged by proxying the upgrade handshake to the workspace and then piping raw bytes both ways. Workspaces inside the container run `aoe serve --auth=none --behind-proxy` and are only reachable through loopback, so CityHall is the sole auth boundary.

Version handling: a global default version plus per-user pins, settable individually or for a selected group; the served image is the settings' image template with `{version}` substituted. New RBAC keys `workspaces.use` (granted to the system member role, including on existing installs), `workspaces.read`, and `workspaces.write` gate the surface. The admin **Workspaces** page shows status/version/activity per user with start/stop/destroy and grouped version pinning; settings gains a Workspaces section; users get an "Open workspace" link.

No published aoe server image exists yet, so `deploy/aoe-image/` carries a reference Dockerfile operators build per version (auto-pull/build tracked in #17; upstream image in agent-of-empires/agent-of-empires#2869). The docker backend assumes CityHall runs natively on the docker host; other topologies are tracked in #18, agent credentials forwarding in #16, richer version management UX in #19, and a same-origin proxy compatibility mode in #20.

Closes #10

## PR Type

- [x] New Feature

## How to test

- [ ] Build the workspace image: `docker build --build-arg AOE_VERSION=<latest aoe tag> -t cityhall/aoe:<tag> deploy/aoe-image/`
- [ ] `cargo run`, log in as admin, open Settings, set the Workspaces default version to `<tag>` and enable workspaces, save
- [ ] Click "Open workspace" in the top bar: the aoe dashboard loads on `http://127.0.0.1:3001` and `docker ps` shows `cityhall-workspace-u1`
- [ ] Interact with the aoe dashboard (create a session, open a live terminal): WebSockets work through the proxy
- [ ] Open the Workspaces admin page: your workspace shows as running with the default version and a last-active time
- [ ] Stop the workspace from the admin page, then reload the workspace tab: it resumes with the same aoe state (volume kept)
- [ ] Select your row, type a different built version, hit "Set version": the next workspace request recreates the container on that version (check `docker ps` image), with sessions intact
- [ ] Set the version to something not built: starting fails with a clear "image not found, build it first" error
- [ ] Destroy the workspace from the admin page: container and `cityhall-workspace-u1-data` volume are gone
- [ ] Open `http://127.0.0.1:3001` in a private window (no session): 401
- [ ] Set idle stop to 1 minute, close all workspace tabs, wait ~2 minutes: `docker ps` shows the container stopped, volume kept
- [ ] Log in as a plain member user: "Open workspace" works, the admin Workspaces nav entry is hidden

## Checklist

- [x] New and existing tests pass
- [x] `cargo fmt` / `cargo clippy` clean (API changes)
- [x] `npm run lint` / `npm run format:check` clean (web changes)
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill). Investigation, plan, and implementation drafted by Claude under my direction; I made the design calls and the manual test steps above are for me to run before marking ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-user workspaces with request-driven start/stop/destroy and status.
  * Added workspace version pinning (single and bulk) with effective version resolution.
  * Added an authenticated HTTP + WebSocket proxy that starts workspaces on demand and tracks activity.
  * Added workspace settings (image template, default version, idle auto-stop) with new UI pages/navigation.
  * Extended permissions and admin role seeding for workspace access.
* **Bug Fixes**
  * Workspace unavailability now returns HTTP 503 with a warning.
* **Documentation**
  * Added/updated workspace API, configuration, lifecycle, and website docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->