### PR TITLE
feat(workspaces): pluggable workspace backends, version management, and admin access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "lettre",
+ "libc",
  "openidconnect",
  "rand 0.10.2",
  "reqwest",
@@ -519,6 +520,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,35 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --locked \
     && cp target/release/cityhall /usr/local/bin/cityhall
 
+# --- Workspace backend CLIs ------------------------------------------------
+# Static docker and kubectl binaries so the containerized CityHall can drive
+# the docker (socket-mounted compose) and kubernetes workspace backends.
+FROM debian:bookworm-slim AS clis
+ARG TARGETARCH
+ARG DOCKER_VERSION=27.5.1
+ARG KUBECTL_VERSION=v1.32.2
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+         amd64) DOCKER_ARCH=x86_64 ;; \
+         arm64) DOCKER_ARCH=aarch64 ;; \
+         *) echo "unsupported arch: $TARGETARCH" && exit 1 ;; \
+       esac \
+    && curl -fsSL "https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz" \
+       | tar -xz --strip-components=1 -C /usr/local/bin docker/docker \
+    && curl -fsSL -o /usr/local/bin/kubectl \
+       "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH:-$(dpkg --print-architecture)}/kubectl" \
+    && chmod +x /usr/local/bin/kubectl
+
 # --- Runtime --------------------------------------------------------------
 FROM debian:bookworm-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
+COPY --from=clis /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=clis /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=api /usr/local/bin/cityhall /usr/local/bin/cityhall
 COPY --from=web /web/dist ./web/dist
 ENV STATIC_DIR=/app/web/dist \

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -40,3 +40,7 @@ tower = "0.5.3"
 tower-http = { version = "0.7.0", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[target.'cfg(unix)'.dependencies]
+# Process-group signaling for the bare-process workspace backend.
+libc = "0.2"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -40,6 +40,9 @@ tower = "0.5.3"
 tower-http = { version = "0.7.0", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Query-string parsing/serialization for the workspace proxy's admin-access
+# exchange (already a transitive dependency via reqwest).
+url = "2"
 
 [target.'cfg(unix)'.dependencies]
 # Process-group signaling for the bare-process workspace backend.

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -14,6 +14,9 @@ pub enum AppError {
     /// A workspace could not be reached or materialized; the message carries
     /// operator guidance (image missing, runtime down...).
     WorkspaceUnavailable(String),
+    /// The workspace's artifact is being fetched/built in the background;
+    /// clients should retry shortly.
+    WorkspaceProvisioning(String),
     Db(sea_orm::DbErr),
 }
 
@@ -31,7 +34,9 @@ impl std::fmt::Display for AppError {
                 write!(f, "{m}")
             }
             AppError::BadRequest(m) | AppError::Internal(m) => write!(f, "{m}"),
-            AppError::WorkspaceUnavailable(m) => write!(f, "{m}"),
+            AppError::WorkspaceUnavailable(m) | AppError::WorkspaceProvisioning(m) => {
+                write!(f, "{m}")
+            }
             AppError::Db(e) => write!(f, "{e}"),
         }
     }
@@ -54,6 +59,15 @@ impl IntoResponse for AppError {
             AppError::WorkspaceUnavailable(m) => {
                 tracing::warn!("workspace unavailable: {m}");
                 (StatusCode::SERVICE_UNAVAILABLE, m)
+            }
+            AppError::WorkspaceProvisioning(m) => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    // Providing a retry hint: provisioning resolves on its own.
+                    [(axum::http::header::RETRY_AFTER, "5")],
+                    Json(json!({ "error": m, "provisioning": true })),
+                )
+                    .into_response();
             }
             AppError::Db(e) => {
                 tracing::error!("database error: {e}");

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::auth::AuthUser;
 use crate::entities::{workspace, workspace_settings};
 use crate::error::AppError;
-use crate::orchestrator::WorkspaceStatus;
+use crate::orchestrator::{binary_key, render_image, WorkspaceStatus};
 use crate::proxy;
 use crate::state::AppState;
 use crate::workspaces::{self, SETTINGS_ID};
@@ -22,6 +22,15 @@ pub struct WorkspaceItem {
     pub pinned_version: Option<String>,
     pub effective_version: Option<String>,
     pub last_active_at: Option<chrono::DateTime<Utc>>,
+    /// Background artifact provisioning (image pull/build, binary download)
+    /// for this user's effective version, when one is underway or failed.
+    pub provisioning: Option<ProvisioningInfo>,
+}
+
+#[derive(Serialize)]
+pub struct ProvisioningInfo {
+    pub message: String,
+    pub failed: bool,
 }
 
 fn status_str(status: Result<WorkspaceStatus, impl std::fmt::Display>) -> &'static str {
@@ -49,7 +58,21 @@ pub async fn list(
     let mut items = Vec::with_capacity(users.len());
     for user in users {
         let row = rows.iter().find(|r| r.user_id == user.id);
-        let effective = row.and_then(|r| workspaces::effective_version(&cfg, r));
+        let effective = row
+            .and_then(|r| workspaces::effective_version(&cfg, r))
+            .or_else(|| cfg.default_version.clone());
+        // Whichever backend runs, the effective version maps to exactly one
+        // artifact key (image ref or binary); probe both.
+        let provisioning = effective
+            .as_ref()
+            .and_then(|v| {
+                let image = render_image(&cfg.image_template, v);
+                state
+                    .provisioning
+                    .state(&image)
+                    .or_else(|| state.provisioning.state(&binary_key(v)))
+            })
+            .map(|(message, failed)| ProvisioningInfo { message, failed });
         items.push(WorkspaceItem {
             user_id: user.id,
             status: match row {
@@ -58,9 +81,10 @@ pub async fn list(
                 None => "not_created",
             },
             pinned_version: row.and_then(|r| r.pinned_version.clone()),
-            effective_version: effective.or_else(|| cfg.default_version.clone()),
+            effective_version: effective,
             last_active_at: row.and_then(|r| r.last_active_at),
             username: user.username,
+            provisioning,
         });
     }
     Ok(Json(items))

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -170,6 +170,10 @@ pub async fn destroy(
 pub struct SetVersionRequest {
     /// `null` (or empty) unpins, following the default version.
     pub pinned_version: Option<String>,
+    /// Recreate currently-running workspaces onto the new version now
+    /// instead of on their next start (default lazy).
+    #[serde(default)]
+    pub restart: bool,
 }
 
 /// PATCH /api/workspaces/{user_id}: pin or unpin the served aoe version. A
@@ -184,6 +188,9 @@ pub async fn set_version(
     caller.require("workspaces.write")?;
     ensure_user_exists(&state, user_id).await?;
     pin_version(&state, user_id, body.pinned_version.clone()).await?;
+    if body.restart {
+        spawn_restarts(state.clone(), vec![user_id]);
+    }
     Ok(Json(
         serde_json::json!({ "pinned_version": normalize(body.pinned_version) }),
     ))
@@ -193,6 +200,10 @@ pub async fn set_version(
 pub struct BulkSetVersionRequest {
     pub user_ids: Vec<i32>,
     pub pinned_version: Option<String>,
+    /// Recreate currently-running workspaces onto the new version now
+    /// instead of on their next start (default lazy).
+    #[serde(default)]
+    pub restart: bool,
 }
 
 /// PATCH /api/workspaces: pin/unpin a group of users in one call (grouped
@@ -209,12 +220,29 @@ pub async fn bulk_set_version(
     for user_id in &body.user_ids {
         ensure_user_exists(&state, *user_id).await?;
     }
-    for user_id in body.user_ids {
-        pin_version(&state, user_id, body.pinned_version.clone()).await?;
+    for user_id in &body.user_ids {
+        pin_version(&state, *user_id, body.pinned_version.clone()).await?;
+    }
+    if body.restart {
+        spawn_restarts(state.clone(), body.user_ids);
     }
     Ok(Json(
         serde_json::json!({ "pinned_version": normalize(body.pinned_version) }),
     ))
+}
+
+/// Eager rollout: recreate the listed users' RUNNING workspaces in the
+/// background, one at a time (a recreate can ride a multi-minute image
+/// provisioning; the PATCH must not hang on it). Failures land in the
+/// provisioning tracker / logs and the list keeps showing live status.
+fn spawn_restarts(state: AppState, user_ids: Vec<i32>) {
+    tokio::spawn(async move {
+        for user_id in user_ids {
+            if let Err(e) = workspaces::restart_if_running(&state, user_id).await {
+                tracing::warn!(user_id, "eager workspace restart failed: {e}");
+            }
+        }
+    });
 }
 
 fn normalize(version: Option<String>) -> Option<String> {

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -132,6 +132,27 @@ pub async fn versions(
     })))
 }
 
+/// POST /api/workspaces/{user_id}/access-url: a short-lived link that opens
+/// `user_id`'s workspace through the proxy for a privileged caller. The
+/// actual access grant (and its audit line) happens when the proxy exchanges
+/// the token; this endpoint only mints it and does not start anything.
+pub async fn access_url(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    caller: AuthUser,
+    Path(user_id): Path<i32>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    caller.require("workspaces.impersonate")?;
+    ensure_user_exists(&state, user_id).await?;
+    let token = proxy::mint_exchange_token(caller.user.id, user_id)?;
+    let query = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair(proxy::ACCESS_PARAM, &token)
+        .finish();
+    Ok(Json(serde_json::json!({
+        "url": format!("{}/?{query}", proxy::public_origin(&headers)),
+    })))
+}
+
 /// POST /api/workspaces/{user_id}/start
 pub async fn start(
     State(state): State<AppState>,

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -114,6 +114,24 @@ pub async fn me(
     })))
 }
 
+/// GET /api/workspaces/versions: discovered stable aoe releases (cached),
+/// newest first, feeding the version dropdowns. Readable by anyone who can
+/// see the workspaces page or the settings page.
+pub async fn versions(
+    State(state): State<AppState>,
+    caller: AuthUser,
+) -> Result<Json<serde_json::Value>, AppError> {
+    if caller.require("workspaces.read").is_err() {
+        caller.require("settings.read")?;
+    }
+    let (versions, stale) = state.versions.versions().await;
+    Ok(Json(serde_json::json!({
+        "latest": versions.first(),
+        "versions": versions,
+        "stale": stale,
+    })))
+}
+
 /// POST /api/workspaces/{user_id}/start
 pub async fn start(
     State(state): State<AppState>,

--- a/api/src/orchestrator/docker.rs
+++ b/api/src/orchestrator/docker.rs
@@ -12,13 +12,17 @@
 //!   container on the named docker network (socket mounted); workspaces join
 //!   that network with no published ports and are dialed by container DNS.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::Deserialize;
 use tokio::process::Command;
 
-use super::{wait_ready, Orchestrator, OrchestratorError, WorkspaceSpec, WorkspaceStatus};
+use super::{
+    wait_ready, Begin, Orchestrator, OrchestratorError, ProvisioningRegistry, WorkspaceSpec,
+    WorkspaceStatus,
+};
 
 /// Port aoe serves on inside the workspace container.
 const AOE_PORT: u16 = 8080;
@@ -26,6 +30,14 @@ const AOE_PORT: u16 = 8080;
 /// as user `aoe`); the per-user volume is mounted here.
 const AOE_DATA_DIR: &str = "/home/aoe/.config/agent-of-empires";
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
+/// Image pulls and first builds legitimately take minutes.
+const PROVISION_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// The reference workspace image build, embedded so a running CityHall can
+/// build missing images without a repo checkout. It needs no build context
+/// (it downloads the release tarball itself), so it is piped to
+/// `docker build -`.
+const AOE_IMAGE_DOCKERFILE: &str = include_str!("../../../deploy/aoe-image/Dockerfile");
 
 pub fn container_name(user_id: i32) -> String {
     format!("cityhall-workspace-u{user_id}")
@@ -40,15 +52,17 @@ pub struct DockerCliOrchestrator {
     /// Shared-network addressing mode: workspaces join this docker network
     /// (no published ports) and are dialed by container DNS name.
     network: Option<String>,
+    provisioning: Arc<ProvisioningRegistry>,
 }
 
 impl DockerCliOrchestrator {
-    pub fn from_env() -> Self {
+    pub fn from_env(provisioning: Arc<ProvisioningRegistry>) -> Self {
         DockerCliOrchestrator {
             cli: std::env::var("CONTAINER_CLI").unwrap_or_else(|_| "docker".to_string()),
             network: std::env::var("WORKSPACE_DOCKER_NETWORK")
                 .ok()
                 .filter(|n| !n.trim().is_empty()),
+            provisioning,
         }
     }
 
@@ -122,11 +136,7 @@ impl DockerCliOrchestrator {
 
     async fn create_and_start(&self, spec: &WorkspaceSpec) -> Result<(), OrchestratorError> {
         if !self.image_exists(&spec.image).await? {
-            return Err(OrchestratorError::ArtifactMissing(format!(
-                "workspace image '{}' not found; build it first (see deploy/aoe-image/) \
-                 or fix the image template / version in the workspace settings",
-                spec.image
-            )));
+            return Err(self.provision_image(spec));
         }
         if let Some(net) = &self.network {
             // Surface a clear error now instead of `docker run`'s "not found"
@@ -164,6 +174,142 @@ impl DockerCliOrchestrator {
             Some(_) => Ok(format!("{name}:{AOE_PORT}")),
             None => self.published_addr(name).await,
         }
+    }
+
+    /// Kick off (or report) background provisioning of a missing image:
+    /// `docker pull`, then a local build from the embedded reference
+    /// Dockerfile. Detached from the request so a closed browser tab cannot
+    /// kill a multi-minute build; callers get a retry-shortly error.
+    fn provision_image(&self, spec: &WorkspaceSpec) -> OrchestratorError {
+        let image = spec.image.clone();
+        let message = format!("pulling image {image}");
+        match self.provisioning.begin(&image, &message) {
+            Begin::AlreadyRunning(msg) => OrchestratorError::Provisioning(msg),
+            Begin::RecentlyFailed(msg) => OrchestratorError::ArtifactMissing(msg),
+            Begin::Started => {
+                let cli = self.cli.clone();
+                let registry = self.provisioning.clone();
+                let version = spec.version.clone();
+                tokio::spawn(provision_image_job(cli, image, version, registry));
+                OrchestratorError::Provisioning(message)
+            }
+        }
+    }
+}
+
+async fn provision_image_job(
+    cli: String,
+    image: String,
+    version: String,
+    registry: Arc<ProvisioningRegistry>,
+) {
+    let pull_err = match provision_run(&cli, &["pull", &image], None, &image).await {
+        Ok(()) => {
+            tracing::info!(%image, "pulled workspace image");
+            registry.succeed(&image);
+            return;
+        }
+        Err(e) => e,
+    };
+    registry.progress(
+        &image,
+        &format!("building image {image} (a first build takes a few minutes)"),
+    );
+    let build_arg = format!("AOE_VERSION={version}");
+    match provision_run(
+        &cli,
+        &["build", "--build-arg", &build_arg, "-t", &image, "-"],
+        Some(AOE_IMAGE_DOCKERFILE),
+        &image,
+    )
+    .await
+    {
+        Ok(()) => {
+            tracing::info!(%image, "built workspace image from the reference Dockerfile");
+            registry.succeed(&image);
+        }
+        Err(build_err) => {
+            tracing::warn!(%image, "workspace image provisioning failed");
+            registry.fail(
+                &image,
+                format!("provisioning image {image} failed; pull: {pull_err}; build: {build_err}"),
+            );
+        }
+    }
+}
+
+/// Run a slow provisioning command with its output streamed to a log file
+/// (build logs can be megabytes); failures return the log tail.
+async fn provision_run(
+    cli: &str,
+    args: &[&str],
+    stdin: Option<&str>,
+    log_name: &str,
+) -> Result<(), String> {
+    let sanitized: String = log_name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    let log_path = std::env::temp_dir().join(format!("cityhall-provision-{sanitized}.log"));
+    let log = std::fs::File::create(&log_path).map_err(|e| format!("cannot open log: {e}"))?;
+    let log_err = log
+        .try_clone()
+        .map_err(|e| format!("cannot open log: {e}"))?;
+
+    let mut cmd = Command::new(cli);
+    cmd.args(args)
+        // kill_on_drop reaps the CLI when the timeout fires; the docker
+        // daemon may still finish server-side, which the next existence
+        // check picks up.
+        .kill_on_drop(true)
+        .stdin(if stdin.is_some() {
+            std::process::Stdio::piped()
+        } else {
+            std::process::Stdio::null()
+        })
+        .stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_err));
+
+    let run = async {
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| format!("failed to run {cli}: {e}"))?;
+        if let Some(payload) = stdin {
+            use tokio::io::AsyncWriteExt;
+            let mut pipe = child.stdin.take().expect("stdin piped");
+            pipe.write_all(payload.as_bytes())
+                .await
+                .map_err(|e| format!("failed to feed {cli} stdin: {e}"))?;
+            drop(pipe);
+        }
+        child.wait().await.map_err(|e| format!("{cli} failed: {e}"))
+    };
+    let status = tokio::time::timeout(PROVISION_TIMEOUT, run)
+        .await
+        .map_err(|_| format!("{cli} {} timed out after {PROVISION_TIMEOUT:?}", args[0]))??;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(log_tail(&log_path))
+    }
+}
+
+/// The last ~500 bytes of a provisioning log, for error messages.
+fn log_tail(path: &std::path::Path) -> String {
+    match std::fs::read_to_string(path) {
+        Ok(s) => {
+            let tail: String = s
+                .chars()
+                .rev()
+                .take(500)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
+            tail.trim().to_string()
+        }
+        Err(_) => "command failed (no log available)".to_string(),
     }
 }
 

--- a/api/src/orchestrator/docker.rs
+++ b/api/src/orchestrator/docker.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use tokio::process::Command;
 
-use super::{Orchestrator, OrchestratorError, WorkspaceSpec, WorkspaceStatus};
+use super::{wait_ready, Orchestrator, OrchestratorError, WorkspaceSpec, WorkspaceStatus};
 
 /// Port aoe serves on inside the workspace container.
 const AOE_PORT: u16 = 8080;
@@ -21,8 +21,6 @@ const AOE_PORT: u16 = 8080;
 /// as user `aoe`); the per-user volume is mounted here.
 const AOE_DATA_DIR: &str = "/home/aoe/.config/agent-of-empires";
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
-/// How long to wait for aoe to accept connections after `docker start`.
-const READY_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub fn container_name(user_id: i32) -> String {
     format!("cityhall-workspace-u{user_id}")
@@ -114,7 +112,7 @@ impl DockerCliOrchestrator {
 
     async fn create_and_start(&self, spec: &WorkspaceSpec) -> Result<(), OrchestratorError> {
         if !self.image_exists(&spec.image).await? {
-            return Err(OrchestratorError::ImageMissing(format!(
+            return Err(OrchestratorError::ArtifactMissing(format!(
                 "workspace image '{}' not found; build it first (see deploy/aoe-image/) \
                  or fix the image template / version in the workspace settings",
                 spec.image
@@ -167,23 +165,6 @@ impl DockerCliOrchestrator {
         .await?;
         Ok(())
     }
-
-    /// Wait until the workspace answers HTTP so the first proxied request does
-    /// not race aoe's startup.
-    async fn wait_ready(&self, addr: &str) -> Result<(), OrchestratorError> {
-        let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
-        loop {
-            if http_probe(addr).await {
-                return Ok(());
-            }
-            if tokio::time::Instant::now() >= deadline {
-                return Err(OrchestratorError::Runtime(format!(
-                    "workspace at {addr} did not become ready within {READY_TIMEOUT:?}"
-                )));
-            }
-            tokio::time::sleep(Duration::from_millis(250)).await;
-        }
-    }
 }
 
 #[async_trait]
@@ -211,7 +192,7 @@ impl Orchestrator for DockerCliOrchestrator {
             }
         }
         let addr = self.published_addr(&name).await?;
-        self.wait_ready(&addr).await?;
+        wait_ready(&addr).await?;
         Ok(addr)
     }
 
@@ -264,31 +245,6 @@ struct InspectConfig {
     labels: Option<std::collections::HashMap<String, String>>,
 }
 
-/// Whether an HTTP server answers at `addr`. A bare TCP connect is not
-/// enough: docker's userland proxy accepts connections on the published port
-/// before the service inside the container listens, so the probe must
-/// actually exchange bytes.
-async fn http_probe(addr: &str) -> bool {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    let probe = async {
-        let mut stream = tokio::net::TcpStream::connect(addr).await.ok()?;
-        stream
-            .write_all(b"GET / HTTP/1.0\r\nHost: workspace\r\n\r\n")
-            .await
-            .ok()?;
-        let mut buf = [0u8; 1];
-        match stream.read(&mut buf).await {
-            Ok(n) if n > 0 => Some(()),
-            _ => None,
-        }
-    };
-    tokio::time::timeout(Duration::from_secs(2), probe)
-        .await
-        .ok()
-        .flatten()
-        .is_some()
-}
-
 /// Parse `docker port` output (`127.0.0.1:55000`, possibly multiple lines with
 /// an IPv6 line like `[::1]:55000`) into a dialable loopback address.
 fn parse_published_addr(out: &str) -> Option<String> {
@@ -320,30 +276,6 @@ mod tests {
             Some("127.0.0.1:55000")
         );
         assert_eq!(parse_published_addr(""), None);
-    }
-
-    #[tokio::test]
-    async fn http_probe_requires_a_response_not_just_a_connect() {
-        use tokio::io::AsyncWriteExt;
-
-        // Accepts and answers: ready.
-        let responder = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = responder.local_addr().unwrap().to_string();
-        tokio::spawn(async move {
-            let (mut sock, _) = responder.accept().await.unwrap();
-            let _ = sock.write_all(b"HTTP/1.0 200 OK\r\n\r\n").await;
-        });
-        assert!(http_probe(&addr).await);
-
-        // Accepts but closes without a byte (docker-proxy with no backend
-        // yet): not ready.
-        let closer = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = closer.local_addr().unwrap().to_string();
-        tokio::spawn(async move {
-            let (sock, _) = closer.accept().await.unwrap();
-            drop(sock);
-        });
-        assert!(!http_probe(&addr).await);
     }
 
     #[test]

--- a/api/src/orchestrator/docker.rs
+++ b/api/src/orchestrator/docker.rs
@@ -3,9 +3,14 @@
 //! Shells out to the `docker` binary (override with `CONTAINER_CLI`, e.g.
 //! `podman`) rather than a docker API crate: the aoe ecosystem already drives
 //! containers through the CLI, it needs no extra dependencies, and only
-//! structured output (`--format '{{json .}}'`) is parsed. This backend assumes
-//! CityHall runs natively on the docker host and reaches workspaces through
-//! loopback-published ephemeral ports; other topologies are separate backends.
+//! structured output (`--format '{{json .}}'`) is parsed.
+//!
+//! Two addressing modes:
+//! - Published (default): CityHall runs natively on the docker host and
+//!   reaches workspaces through loopback-published ephemeral ports.
+//! - Shared network (`WORKSPACE_DOCKER_NETWORK`): CityHall itself runs in a
+//!   container on the named docker network (socket mounted); workspaces join
+//!   that network with no published ports and are dialed by container DNS.
 
 use std::time::Duration;
 
@@ -32,12 +37,18 @@ pub fn volume_name(user_id: i32) -> String {
 
 pub struct DockerCliOrchestrator {
     cli: String,
+    /// Shared-network addressing mode: workspaces join this docker network
+    /// (no published ports) and are dialed by container DNS name.
+    network: Option<String>,
 }
 
 impl DockerCliOrchestrator {
     pub fn from_env() -> Self {
         DockerCliOrchestrator {
             cli: std::env::var("CONTAINER_CLI").unwrap_or_else(|_| "docker".to_string()),
+            network: std::env::var("WORKSPACE_DOCKER_NETWORK")
+                .ok()
+                .filter(|n| !n.trim().is_empty()),
         }
     }
 
@@ -79,12 +90,11 @@ impl DockerCliOrchestrator {
                 let raw: InspectOutput = serde_json::from_str(json.trim()).map_err(|e| {
                     OrchestratorError::Runtime(format!("unparseable inspect output: {e}"))
                 })?;
+                let labels = raw.config.labels.unwrap_or_default();
                 Ok(Some(ContainerState {
                     running: raw.state.running,
-                    version_label: raw
-                        .config
-                        .labels
-                        .and_then(|l| l.get("cityhall.workspace.version").cloned()),
+                    version_label: labels.get("cityhall.workspace.version").cloned(),
+                    network_label: labels.get("cityhall.workspace.network").cloned(),
                 }))
             }
             None => Ok(None),
@@ -118,6 +128,19 @@ impl DockerCliOrchestrator {
                 spec.image
             )));
         }
+        if let Some(net) = &self.network {
+            // Surface a clear error now instead of `docker run`'s "not found"
+            // (which run() would misread as a missing container).
+            if self
+                .run(&["network", "inspect", "--format", "{{.Id}}", net])
+                .await?
+                .is_none()
+            {
+                return Err(OrchestratorError::Runtime(format!(
+                    "docker network '{net}' (WORKSPACE_DOCKER_NETWORK) does not exist"
+                )));
+            }
+        }
         let volume = volume_name(spec.user_id);
         self.run(&[
             "volume",
@@ -128,43 +151,74 @@ impl DockerCliOrchestrator {
         ])
         .await?;
 
-        let name = container_name(spec.user_id);
-        let user_label = format!("cityhall.user_id={}", spec.user_id);
-        let version_label = format!("cityhall.workspace.version={}", spec.version);
-        let mount = format!("{volume}:{AOE_DATA_DIR}");
-        let publish = format!("127.0.0.1:0:{AOE_PORT}");
-        let port = AOE_PORT.to_string();
-        self.run(&[
-            "run",
-            "-d",
-            "--name",
-            &name,
-            "--label",
-            "cityhall.managed=true",
-            "--label",
-            &user_label,
-            "--label",
-            &version_label,
-            "-v",
-            &mount,
-            "-p",
-            &publish,
+        let args = run_args(spec, self.network.as_deref());
+        self.run(&args.iter().map(String::as_str).collect::<Vec<_>>())
+            .await?;
+        Ok(())
+    }
+
+    /// The address the proxy dials: container DNS on the shared network, or
+    /// the loopback published port.
+    async fn addr(&self, name: &str) -> Result<String, OrchestratorError> {
+        match &self.network {
+            Some(_) => Ok(format!("{name}:{AOE_PORT}")),
+            None => self.published_addr(name).await,
+        }
+    }
+}
+
+/// The full `docker run` invocation for a workspace container.
+fn run_args(spec: &WorkspaceSpec, network: Option<&str>) -> Vec<String> {
+    let name = container_name(spec.user_id);
+    let volume = volume_name(spec.user_id);
+    let mut args: Vec<String> = vec![
+        "run".into(),
+        "-d".into(),
+        "--name".into(),
+        name,
+        "--label".into(),
+        "cityhall.managed=true".into(),
+        "--label".into(),
+        format!("cityhall.user_id={}", spec.user_id),
+        "--label".into(),
+        format!("cityhall.workspace.version={}", spec.version),
+        "-v".into(),
+        format!("{volume}:{AOE_DATA_DIR}"),
+    ];
+    match network {
+        Some(net) => {
+            // Reachable by container DNS from inside the network only; the
+            // addressing mode is recorded so flipping it recreates the
+            // container.
+            args.push("--label".into());
+            args.push(format!("cityhall.workspace.network={net}"));
+            args.push("--network".into());
+            args.push(net.into());
+        }
+        None => {
+            args.push("-p".into());
+            args.push(format!("127.0.0.1:0:{AOE_PORT}"));
+        }
+    }
+    args.extend(
+        [
             &spec.image,
             "aoe",
             "serve",
             "--host",
             "0.0.0.0",
             "--port",
-            &port,
-            // CityHall's session gates the proxy; the container port is only
-            // published on loopback.
+            &AOE_PORT.to_string(),
+            // CityHall's session gates the proxy; the container port is never
+            // reachable from outside (loopback publish or internal network).
             "--auth",
             "none",
             "--behind-proxy",
-        ])
-        .await?;
-        Ok(())
-    }
+        ]
+        .iter()
+        .map(|s| s.to_string()),
+    );
+    args
 }
 
 #[async_trait]
@@ -172,13 +226,17 @@ impl Orchestrator for DockerCliOrchestrator {
     async fn ensure_started(&self, spec: &WorkspaceSpec) -> Result<String, OrchestratorError> {
         let name = container_name(spec.user_id);
         match self.inspect(&name).await? {
-            Some(state) if state.version_label.as_deref() != Some(spec.version.as_str()) => {
-                // Version drift: recreate the container, keeping the volume.
+            Some(state)
+                if state.version_label.as_deref() != Some(spec.version.as_str())
+                    || state.network_label != self.network =>
+            {
+                // Version or addressing drift: recreate the container,
+                // keeping the volume.
                 tracing::info!(
                     user_id = spec.user_id,
                     from = state.version_label.as_deref().unwrap_or("unknown"),
                     to = %spec.version,
-                    "recreating workspace for version change"
+                    "recreating workspace for version or addressing change"
                 );
                 self.run(&["rm", "-f", &name]).await?;
                 self.create_and_start(spec).await?;
@@ -191,7 +249,7 @@ impl Orchestrator for DockerCliOrchestrator {
                 self.create_and_start(spec).await?;
             }
         }
-        let addr = self.published_addr(&name).await?;
+        let addr = self.addr(&name).await?;
         wait_ready(&addr).await?;
         Ok(addr)
     }
@@ -213,7 +271,7 @@ impl Orchestrator for DockerCliOrchestrator {
         match self.inspect(&name).await? {
             None => Ok(WorkspaceStatus::NotCreated),
             Some(state) if state.running => Ok(WorkspaceStatus::Running {
-                addr: self.published_addr(&name).await?,
+                addr: self.addr(&name).await?,
             }),
             Some(_) => Ok(WorkspaceStatus::Stopped),
         }
@@ -223,6 +281,7 @@ impl Orchestrator for DockerCliOrchestrator {
 struct ContainerState {
     running: bool,
     version_label: Option<String>,
+    network_label: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -287,5 +346,36 @@ mod tests {
             raw.config.labels.unwrap().get("cityhall.workspace.version"),
             Some(&"v1.0.0".to_string())
         );
+    }
+
+    fn spec() -> WorkspaceSpec {
+        WorkspaceSpec {
+            user_id: 42,
+            image: "cityhall/aoe:v1.0.0".to_string(),
+            version: "v1.0.0".to_string(),
+        }
+    }
+
+    #[test]
+    fn published_mode_publishes_loopback_and_no_network() {
+        let args = run_args(&spec(), None);
+        let publish_at = args.iter().position(|a| a == "-p").unwrap();
+        assert_eq!(args[publish_at + 1], "127.0.0.1:0:8080");
+        assert!(!args.iter().any(|a| a == "--network"));
+        assert!(!args
+            .iter()
+            .any(|a| a.starts_with("cityhall.workspace.network=")));
+    }
+
+    #[test]
+    fn network_mode_joins_network_and_publishes_nothing() {
+        let args = run_args(&spec(), Some("cityhall-workspaces"));
+        let net_at = args.iter().position(|a| a == "--network").unwrap();
+        assert_eq!(args[net_at + 1], "cityhall-workspaces");
+        assert!(!args.iter().any(|a| a == "-p"));
+        // The mode is recorded so flipping WORKSPACE_DOCKER_NETWORK recreates.
+        assert!(args
+            .iter()
+            .any(|a| a == "cityhall.workspace.network=cityhall-workspaces"));
     }
 }

--- a/api/src/orchestrator/kubernetes.rs
+++ b/api/src/orchestrator/kubernetes.rs
@@ -1,0 +1,451 @@
+//! Kubernetes workspace backend.
+//!
+//! Shells out to `kubectl` (mirroring the docker backend's CLI approach: no
+//! API-client dependencies, only structured `-o json` output is parsed) and
+//! assumes CityHall runs in-cluster with a ServiceAccount allowed to manage
+//! deployments, services, and PVCs in the workspace namespace (see
+//! deploy/k8s/). Per user it reconciles one PVC (the data volume), one
+//! ClusterIP Service (the stable endpoint), and one scale-to-zero Deployment
+//! with `strategy: Recreate` so at most one pod ever mounts the volume.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::json;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+use super::{http_probe, Orchestrator, OrchestratorError, WorkspaceSpec, WorkspaceStatus};
+
+/// Port aoe serves on inside the workspace pod.
+const AOE_PORT: u16 = 8080;
+/// Where the aoe app dir lives inside the pod (the reference image runs as
+/// user `aoe`); the PVC is mounted here.
+const AOE_DATA_DIR: &str = "/home/aoe/.config/agent-of-empires";
+const CLI_TIMEOUT: Duration = Duration::from_secs(60);
+/// Pod scheduling plus a cold image pull can far exceed the shared 15s
+/// readiness window, so this backend polls with its own budget.
+const READY_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// In-cluster namespace file mounted into every pod with a ServiceAccount.
+const NAMESPACE_FILE: &str = "/var/run/secrets/kubernetes.io/serviceaccount/namespace";
+
+pub fn object_name(user_id: i32) -> String {
+    format!("cityhall-workspace-u{user_id}")
+}
+
+pub fn pvc_name(user_id: i32) -> String {
+    format!("cityhall-workspace-u{user_id}-data")
+}
+
+pub struct KubectlOrchestrator {
+    namespace: String,
+    /// PVC size request, e.g. `5Gi`.
+    volume_size: String,
+    /// Optional PVC storage class; the cluster default when unset.
+    storage_class: Option<String>,
+}
+
+impl KubectlOrchestrator {
+    pub fn from_env() -> Self {
+        let namespace = std::env::var("WORKSPACE_K8S_NAMESPACE")
+            .ok()
+            .filter(|n| !n.trim().is_empty())
+            .or_else(|| {
+                std::fs::read_to_string(NAMESPACE_FILE)
+                    .ok()
+                    .map(|n| n.trim().to_string())
+                    .filter(|n| !n.is_empty())
+            })
+            .unwrap_or_else(|| "default".to_string());
+        KubectlOrchestrator {
+            namespace,
+            volume_size: std::env::var("WORKSPACE_K8S_VOLUME_SIZE")
+                .ok()
+                .filter(|s| !s.trim().is_empty())
+                .unwrap_or_else(|| "5Gi".to_string()),
+            storage_class: std::env::var("WORKSPACE_K8S_STORAGE_CLASS")
+                .ok()
+                .filter(|s| !s.trim().is_empty()),
+        }
+    }
+
+    /// Run kubectl (namespace pinned), returning stdout on success. NotFound
+    /// is reported as `Ok(None)` so callers can treat missing objects as
+    /// state, not failure.
+    async fn run(
+        &self,
+        args: &[&str],
+        stdin: Option<String>,
+    ) -> Result<Option<String>, OrchestratorError> {
+        let mut cmd = Command::new("kubectl");
+        cmd.arg("-n")
+            .arg(&self.namespace)
+            .args(args)
+            .kill_on_drop(true)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        let run = async {
+            let mut child = cmd
+                .spawn()
+                .map_err(|e| OrchestratorError::Runtime(format!("failed to run kubectl: {e}")))?;
+            if let Some(payload) = stdin {
+                let mut pipe = child.stdin.take().expect("stdin piped");
+                pipe.write_all(payload.as_bytes()).await.map_err(|e| {
+                    OrchestratorError::Runtime(format!("failed to feed kubectl stdin: {e}"))
+                })?;
+                drop(pipe);
+            }
+            child
+                .wait_with_output()
+                .await
+                .map_err(|e| OrchestratorError::Runtime(format!("kubectl failed: {e}")))
+        };
+        let output = tokio::time::timeout(CLI_TIMEOUT, run).await.map_err(|_| {
+            OrchestratorError::Runtime(format!("kubectl {} timed out", args.join(" ")))
+        })??;
+
+        if output.status.success() {
+            return Ok(Some(String::from_utf8_lossy(&output.stdout).into_owned()));
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.to_lowercase().contains("not found") {
+            return Ok(None);
+        }
+        Err(OrchestratorError::Runtime(format!(
+            "kubectl {} failed: {}",
+            args.join(" "),
+            stderr.trim()
+        )))
+    }
+
+    /// The stable service DNS address the proxy dials from in-cluster.
+    fn addr(&self, user_id: i32) -> String {
+        format!("{}.{}.svc:{AOE_PORT}", object_name(user_id), self.namespace)
+    }
+
+    /// Poll until the workspace answers HTTP, surfacing image-pull failures
+    /// as `ArtifactMissing` instead of a generic timeout.
+    async fn wait_ready_or_diagnose(&self, spec: &WorkspaceSpec) -> Result<(), OrchestratorError> {
+        let addr = self.addr(spec.user_id);
+        let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
+        loop {
+            if http_probe(&addr).await {
+                return Ok(());
+            }
+            if let Some(reason) = self.pod_waiting_reason(spec.user_id).await? {
+                if matches!(
+                    reason.as_str(),
+                    "ErrImagePull" | "ImagePullBackOff" | "InvalidImageName"
+                ) {
+                    return Err(OrchestratorError::ArtifactMissing(format!(
+                        "workspace image '{}' cannot be pulled ({reason}); push it to a \
+                         registry the cluster can reach or fix the image template / \
+                         version in the workspace settings",
+                        spec.image
+                    )));
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(OrchestratorError::Runtime(format!(
+                    "workspace at {addr} did not become ready within {READY_TIMEOUT:?}"
+                )));
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    /// The waiting reason of the workspace pod's container, if any.
+    async fn pod_waiting_reason(&self, user_id: i32) -> Result<Option<String>, OrchestratorError> {
+        let selector = format!("cityhall.workspace={}", object_name(user_id));
+        let out = self
+            .run(&["get", "pods", "-l", &selector, "-o", "json"], None)
+            .await?;
+        let Some(json) = out else { return Ok(None) };
+        let pods: PodList = serde_json::from_str(json.trim())
+            .map_err(|e| OrchestratorError::Runtime(format!("unparseable pod list: {e}")))?;
+        Ok(pods
+            .items
+            .into_iter()
+            .flat_map(|p| p.status.container_statuses.unwrap_or_default())
+            .find_map(|c| c.state.and_then(|s| s.waiting).map(|w| w.reason)))
+    }
+}
+
+#[async_trait]
+impl Orchestrator for KubectlOrchestrator {
+    async fn ensure_started(&self, spec: &WorkspaceSpec) -> Result<String, OrchestratorError> {
+        // Declarative reconcile: apply always renders the desired running
+        // state (replicas 1, current image), so first start, resume, and
+        // version drift are all the same operation.
+        let manifests = render_manifests(
+            spec,
+            &self.namespace,
+            &self.volume_size,
+            self.storage_class.as_deref(),
+        );
+        self.run(&["apply", "-f", "-"], Some(manifests.to_string()))
+            .await?;
+        self.wait_ready_or_diagnose(spec).await?;
+        Ok(self.addr(spec.user_id))
+    }
+
+    async fn stop(&self, user_id: i32) -> Result<(), OrchestratorError> {
+        self.run(
+            &["scale", "deployment", &object_name(user_id), "--replicas=0"],
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn destroy(&self, user_id: i32) -> Result<(), OrchestratorError> {
+        let selector = format!("cityhall.user_id={user_id}");
+        // --wait=false: PVC finalizers can hold deletion for minutes; the
+        // objects are already Terminating and the admin action should not
+        // hang on storage teardown.
+        self.run(
+            &[
+                "delete",
+                "deployment,service,pvc",
+                "-l",
+                &selector,
+                "--ignore-not-found=true",
+                "--wait=false",
+            ],
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn status(&self, user_id: i32) -> Result<WorkspaceStatus, OrchestratorError> {
+        let out = self
+            .run(
+                &["get", "deployment", &object_name(user_id), "-o", "json"],
+                None,
+            )
+            .await?;
+        let Some(json) = out else {
+            return Ok(WorkspaceStatus::NotCreated);
+        };
+        let deployment: Deployment = serde_json::from_str(json.trim())
+            .map_err(|e| OrchestratorError::Runtime(format!("unparseable deployment: {e}")))?;
+        if deployment.status.ready_replicas.unwrap_or(0) >= 1 {
+            Ok(WorkspaceStatus::Running {
+                addr: self.addr(user_id),
+            })
+        } else {
+            // Scaled to zero, scheduling, or pulling: not reachable yet.
+            Ok(WorkspaceStatus::Stopped)
+        }
+    }
+}
+
+/// The desired-state manifests for one workspace: PVC + Service + Deployment,
+/// as a `kind: List` JSON document `kubectl apply` consumes from stdin.
+fn render_manifests(
+    spec: &WorkspaceSpec,
+    namespace: &str,
+    volume_size: &str,
+    storage_class: Option<&str>,
+) -> serde_json::Value {
+    let name = object_name(spec.user_id);
+    let labels = json!({
+        "cityhall.managed": "true",
+        "cityhall.user_id": spec.user_id.to_string(),
+        "cityhall.workspace": name,
+    });
+    let mut pvc_spec = json!({
+        "accessModes": ["ReadWriteOnce"],
+        "resources": { "requests": { "storage": volume_size } },
+    });
+    if let Some(class) = storage_class {
+        pvc_spec["storageClassName"] = json!(class);
+    }
+    json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [
+            {
+                "apiVersion": "v1",
+                "kind": "PersistentVolumeClaim",
+                "metadata": { "name": pvc_name(spec.user_id), "namespace": namespace, "labels": labels },
+                "spec": pvc_spec,
+            },
+            {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": { "name": name, "namespace": namespace, "labels": labels },
+                "spec": {
+                    "selector": { "cityhall.workspace": name },
+                    "ports": [{ "port": AOE_PORT, "targetPort": AOE_PORT }],
+                },
+            },
+            {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "metadata": { "name": name, "namespace": namespace, "labels": labels },
+                "spec": {
+                    "replicas": 1,
+                    // Never two pods on one RWO volume during a version change.
+                    "strategy": { "type": "Recreate" },
+                    "selector": { "matchLabels": { "cityhall.workspace": name } },
+                    "template": {
+                        "metadata": {
+                            "labels": labels,
+                            // Version drives pod recreation on apply.
+                            "annotations": { "cityhall.workspace.version": spec.version },
+                        },
+                        "spec": {
+                            "containers": [{
+                                "name": "aoe",
+                                "image": spec.image,
+                                "command": ["aoe"],
+                                "args": [
+                                    "serve",
+                                    "--host", "0.0.0.0",
+                                    "--port", AOE_PORT.to_string(),
+                                    // CityHall's session gates the proxy; the
+                                    // shipped NetworkPolicy keeps other pods out.
+                                    "--auth", "none",
+                                    "--behind-proxy",
+                                ],
+                                "ports": [{ "containerPort": AOE_PORT }],
+                                "volumeMounts": [{ "name": "data", "mountPath": AOE_DATA_DIR }],
+                            }],
+                            "volumes": [{
+                                "name": "data",
+                                "persistentVolumeClaim": { "claimName": pvc_name(spec.user_id) },
+                            }],
+                        },
+                    },
+                },
+            },
+        ],
+    })
+}
+
+#[derive(Deserialize)]
+struct Deployment {
+    status: DeploymentStatus,
+}
+
+#[derive(Deserialize)]
+struct DeploymentStatus {
+    #[serde(rename = "readyReplicas")]
+    ready_replicas: Option<i32>,
+}
+
+#[derive(Deserialize)]
+struct PodList {
+    items: Vec<Pod>,
+}
+
+#[derive(Deserialize)]
+struct Pod {
+    status: PodStatus,
+}
+
+#[derive(Deserialize)]
+struct PodStatus {
+    #[serde(rename = "containerStatuses")]
+    container_statuses: Option<Vec<ContainerStatus>>,
+}
+
+#[derive(Deserialize)]
+struct ContainerStatus {
+    state: Option<ContainerStateK8s>,
+}
+
+#[derive(Deserialize)]
+struct ContainerStateK8s {
+    waiting: Option<WaitingState>,
+}
+
+#[derive(Deserialize)]
+struct WaitingState {
+    reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> WorkspaceSpec {
+        WorkspaceSpec {
+            user_id: 42,
+            image: "registry.example.com/aoe:v1.0.0".to_string(),
+            version: "v1.0.0".to_string(),
+        }
+    }
+
+    #[test]
+    fn names_are_deterministic() {
+        assert_eq!(object_name(42), "cityhall-workspace-u42");
+        assert_eq!(pvc_name(42), "cityhall-workspace-u42-data");
+    }
+
+    #[test]
+    fn manifests_render_pvc_service_and_recreate_deployment() {
+        let m = render_manifests(&spec(), "cityhall", "5Gi", None);
+        let items = m["items"].as_array().unwrap();
+        assert_eq!(items.len(), 3);
+        let (pvc, svc, dep) = (&items[0], &items[1], &items[2]);
+
+        assert_eq!(pvc["kind"], "PersistentVolumeClaim");
+        assert_eq!(pvc["metadata"]["name"], "cityhall-workspace-u42-data");
+        assert_eq!(pvc["spec"]["resources"]["requests"]["storage"], "5Gi");
+        // No storageClassName key unless configured: the cluster default applies.
+        assert!(pvc["spec"].get("storageClassName").is_none());
+
+        assert_eq!(
+            svc["spec"]["selector"]["cityhall.workspace"],
+            "cityhall-workspace-u42"
+        );
+
+        assert_eq!(dep["spec"]["strategy"]["type"], "Recreate");
+        assert_eq!(dep["spec"]["replicas"], 1);
+        assert_eq!(
+            dep["spec"]["template"]["metadata"]["annotations"]["cityhall.workspace.version"],
+            "v1.0.0"
+        );
+        let container = &dep["spec"]["template"]["spec"]["containers"][0];
+        assert_eq!(container["image"], "registry.example.com/aoe:v1.0.0");
+        assert_eq!(
+            container["volumeMounts"][0]["mountPath"],
+            "/home/aoe/.config/agent-of-empires"
+        );
+    }
+
+    #[test]
+    fn manifests_pin_storage_class_when_configured() {
+        let m = render_manifests(&spec(), "cityhall", "10Gi", Some("fast-ssd"));
+        assert_eq!(m["items"][0]["spec"]["storageClassName"], "fast-ssd");
+    }
+
+    #[test]
+    fn deployment_status_parses() {
+        let running: Deployment =
+            serde_json::from_str(r#"{"status":{"readyReplicas":1}}"#).unwrap();
+        assert_eq!(running.status.ready_replicas, Some(1));
+        let stopped: Deployment = serde_json::from_str(r#"{"status":{}}"#).unwrap();
+        assert_eq!(stopped.status.ready_replicas, None);
+    }
+
+    #[test]
+    fn pod_waiting_reason_parses() {
+        let json = r#"{"items":[{"status":{"containerStatuses":[
+            {"state":{"waiting":{"reason":"ImagePullBackOff","message":"..."}}}
+        ]}}]}"#;
+        let pods: PodList = serde_json::from_str(json).unwrap();
+        let reason = pods
+            .items
+            .into_iter()
+            .flat_map(|p| p.status.container_statuses.unwrap_or_default())
+            .find_map(|c| c.state.and_then(|s| s.waiting).map(|w| w.reason));
+        assert_eq!(reason.as_deref(), Some("ImagePullBackOff"));
+    }
+}

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -41,6 +41,9 @@ pub enum OrchestratorError {
     /// The workspace artifact (docker image, aoe binary...) is not available;
     /// carries operator guidance.
     ArtifactMissing(String),
+    /// The artifact is being fetched or built in the background; carries a
+    /// progress message. Callers should retry shortly.
+    Provisioning(String),
     /// Any other backend failure (daemon down, command failed...).
     Runtime(String),
 }
@@ -48,7 +51,9 @@ pub enum OrchestratorError {
 impl std::fmt::Display for OrchestratorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            OrchestratorError::ArtifactMissing(m) | OrchestratorError::Runtime(m) => {
+            OrchestratorError::ArtifactMissing(m)
+            | OrchestratorError::Provisioning(m)
+            | OrchestratorError::Runtime(m) => {
                 write!(f, "{m}")
             }
         }
@@ -77,18 +82,115 @@ pub trait Orchestrator: Send + Sync {
     async fn status(&self, user_id: i32) -> Result<WorkspaceStatus, OrchestratorError>;
 }
 
-/// The backend selected by `WORKSPACE_BACKEND` (default `docker`). Invalid
+/// The backend selected by `WORKSPACE_BACKEND` (default `docker`), plus the
+/// provisioning registry it reports slow artifact jobs through. Invalid
 /// values fail CityHall startup instead of surfacing on first workspace use.
-pub fn from_env() -> Result<Arc<dyn Orchestrator>, String> {
+pub fn from_env() -> Result<(Arc<dyn Orchestrator>, Arc<ProvisioningRegistry>), String> {
+    let registry = Arc::new(ProvisioningRegistry::default());
     let backend = std::env::var("WORKSPACE_BACKEND").unwrap_or_else(|_| "docker".to_string());
-    match backend.as_str() {
-        "docker" => Ok(Arc::new(docker::DockerCliOrchestrator::from_env())),
-        "kubernetes" => Ok(Arc::new(kubernetes::KubectlOrchestrator::from_env())),
+    let orchestrator: Arc<dyn Orchestrator> = match backend.as_str() {
+        "docker" => Arc::new(docker::DockerCliOrchestrator::from_env(registry.clone())),
+        "kubernetes" => Arc::new(kubernetes::KubectlOrchestrator::from_env()),
         #[cfg(unix)]
-        "process" => Ok(Arc::new(process::ProcessOrchestrator::from_env())),
-        other => Err(format!(
-            "unknown WORKSPACE_BACKEND '{other}' (expected docker, kubernetes, or process)"
-        )),
+        "process" => Arc::new(process::ProcessOrchestrator::from_env(registry.clone())),
+        other => {
+            return Err(format!(
+                "unknown WORKSPACE_BACKEND '{other}' (expected docker, kubernetes, or process)"
+            ))
+        }
+    };
+    Ok((orchestrator, registry))
+}
+
+/// Registry key for a version's process-backend binary; shared with the
+/// workspaces handler so the admin list can look up progress for a user's
+/// effective version whichever backend runs it.
+pub fn binary_key(version: &str) -> String {
+    format!("aoe-binary-{version}")
+}
+
+/// How long a failed provisioning attempt stays sticky before a new request
+/// may retry it. Prevents every page load from re-running a doomed
+/// multi-minute build while keeping the failure visible.
+const FAILED_RETRY_AFTER: Duration = Duration::from_secs(60);
+
+/// What a backend should do after asking to begin provisioning an artifact.
+pub enum Begin {
+    /// No job was running: the caller must spawn one.
+    Started,
+    /// A job is already running with this progress message.
+    AlreadyRunning(String),
+    /// The last attempt failed recently; carries its error.
+    RecentlyFailed(String),
+}
+
+enum ProvisioningState {
+    Running(String),
+    Failed {
+        message: String,
+        at: tokio::time::Instant,
+    },
+}
+
+/// Tracks background artifact provisioning (image pulls/builds, binary
+/// downloads) by artifact key, single-flight per artifact with sticky
+/// failures. Shared between the backends (writers) and the admin API
+/// (reader).
+#[derive(Default)]
+pub struct ProvisioningRegistry {
+    entries: std::sync::Mutex<std::collections::HashMap<String, ProvisioningState>>,
+}
+
+impl ProvisioningRegistry {
+    /// Atomically claim the right to provision `key`, marking it running.
+    pub fn begin(&self, key: &str, message: &str) -> Begin {
+        let mut entries = self.entries.lock().unwrap();
+        match entries.get(key) {
+            Some(ProvisioningState::Running(msg)) => Begin::AlreadyRunning(msg.clone()),
+            Some(ProvisioningState::Failed { message, at })
+                if at.elapsed() < FAILED_RETRY_AFTER =>
+            {
+                Begin::RecentlyFailed(message.clone())
+            }
+            _ => {
+                entries.insert(
+                    key.to_string(),
+                    ProvisioningState::Running(message.to_string()),
+                );
+                Begin::Started
+            }
+        }
+    }
+
+    /// Update the progress message of a running job.
+    pub fn progress(&self, key: &str, message: &str) {
+        self.entries.lock().unwrap().insert(
+            key.to_string(),
+            ProvisioningState::Running(message.to_string()),
+        );
+    }
+
+    pub fn succeed(&self, key: &str) {
+        self.entries.lock().unwrap().remove(key);
+    }
+
+    pub fn fail(&self, key: &str, message: String) {
+        self.entries.lock().unwrap().insert(
+            key.to_string(),
+            ProvisioningState::Failed {
+                message,
+                at: tokio::time::Instant::now(),
+            },
+        );
+    }
+
+    /// Current state of `key` for display: `(message, failed)`.
+    pub fn state(&self, key: &str) -> Option<(String, bool)> {
+        match self.entries.lock().unwrap().get(key) {
+            Some(ProvisioningState::Running(msg)) => Some((msg.clone(), false)),
+            Some(ProvisioningState::Failed { message, .. }) => Some((message.clone(), true)),
+            None => None,
+        }
     }
 }
 
@@ -157,6 +259,34 @@ mod tests {
             render_image("cityhall/aoe:latest", "v1"),
             "cityhall/aoe:latest"
         );
+    }
+
+    #[tokio::test]
+    async fn provisioning_registry_is_single_flight_with_sticky_failures() {
+        let reg = ProvisioningRegistry::default();
+        assert!(reg.state("img").is_none());
+
+        // First begin claims the job; a second sees it running.
+        assert!(matches!(reg.begin("img", "pulling"), Begin::Started));
+        assert!(matches!(
+            reg.begin("img", "pulling"),
+            Begin::AlreadyRunning(m) if m == "pulling"
+        ));
+        reg.progress("img", "building");
+        assert_eq!(reg.state("img"), Some(("building".to_string(), false)));
+
+        // Fresh failures are sticky: no immediate re-run, message visible.
+        reg.fail("img", "boom".to_string());
+        assert!(matches!(
+            reg.begin("img", "pulling"),
+            Begin::RecentlyFailed(m) if m == "boom"
+        ));
+        assert_eq!(reg.state("img"), Some(("boom".to_string(), true)));
+
+        // Success clears the entry; unrelated keys are independent.
+        assert!(matches!(reg.begin("other", "pulling"), Begin::Started));
+        reg.succeed("other");
+        assert!(reg.state("other").is_none());
     }
 
     #[tokio::test]

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -6,7 +6,9 @@
 //! treats the runtime as the source of truth for liveness.
 
 pub mod docker;
+pub mod kubernetes;
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -71,6 +73,19 @@ pub trait Orchestrator: Send + Sync {
 
     /// Current runtime state.
     async fn status(&self, user_id: i32) -> Result<WorkspaceStatus, OrchestratorError>;
+}
+
+/// The backend selected by `WORKSPACE_BACKEND` (default `docker`). Invalid
+/// values fail CityHall startup instead of surfacing on first workspace use.
+pub fn from_env() -> Result<Arc<dyn Orchestrator>, String> {
+    let backend = std::env::var("WORKSPACE_BACKEND").unwrap_or_else(|_| "docker".to_string());
+    match backend.as_str() {
+        "docker" => Ok(Arc::new(docker::DockerCliOrchestrator::from_env())),
+        "kubernetes" => Ok(Arc::new(kubernetes::KubectlOrchestrator::from_env())),
+        other => Err(format!(
+            "unknown WORKSPACE_BACKEND '{other}' (expected docker or kubernetes)"
+        )),
+    }
 }
 
 /// Render an image template by substituting the `{version}` placeholder.

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -7,6 +7,8 @@
 
 pub mod docker;
 pub mod kubernetes;
+#[cfg(unix)]
+pub mod process;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -82,8 +84,10 @@ pub fn from_env() -> Result<Arc<dyn Orchestrator>, String> {
     match backend.as_str() {
         "docker" => Ok(Arc::new(docker::DockerCliOrchestrator::from_env())),
         "kubernetes" => Ok(Arc::new(kubernetes::KubectlOrchestrator::from_env())),
+        #[cfg(unix)]
+        "process" => Ok(Arc::new(process::ProcessOrchestrator::from_env())),
         other => Err(format!(
-            "unknown WORKSPACE_BACKEND '{other}' (expected docker or kubernetes)"
+            "unknown WORKSPACE_BACKEND '{other}' (expected docker, kubernetes, or process)"
         )),
     }
 }

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -7,6 +7,8 @@
 
 pub mod docker;
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 
 /// Everything a backend needs to materialize a user's workspace.
@@ -32,8 +34,9 @@ pub enum WorkspaceStatus {
 
 #[derive(Debug)]
 pub enum OrchestratorError {
-    /// The workspace image is not available; carries operator guidance.
-    ImageMissing(String),
+    /// The workspace artifact (docker image, aoe binary...) is not available;
+    /// carries operator guidance.
+    ArtifactMissing(String),
     /// Any other backend failure (daemon down, command failed...).
     Runtime(String),
 }
@@ -41,7 +44,7 @@ pub enum OrchestratorError {
 impl std::fmt::Display for OrchestratorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            OrchestratorError::ImageMissing(m) | OrchestratorError::Runtime(m) => {
+            OrchestratorError::ArtifactMissing(m) | OrchestratorError::Runtime(m) => {
                 write!(f, "{m}")
             }
         }
@@ -75,6 +78,51 @@ pub fn render_image(template: &str, version: &str) -> String {
     template.replace("{version}", version)
 }
 
+/// How long to wait for aoe to accept connections after a start.
+const READY_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Wait until the workspace answers HTTP so the first proxied request does
+/// not race aoe's startup.
+pub(crate) async fn wait_ready(addr: &str) -> Result<(), OrchestratorError> {
+    let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
+    loop {
+        if http_probe(addr).await {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(OrchestratorError::Runtime(format!(
+                "workspace at {addr} did not become ready within {READY_TIMEOUT:?}"
+            )));
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Whether an HTTP server answers at `addr`. A bare TCP connect is not
+/// enough: docker's userland proxy accepts connections on the published port
+/// before the service inside the container listens, so the probe must
+/// actually exchange bytes.
+pub(crate) async fn http_probe(addr: &str) -> bool {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let probe = async {
+        let mut stream = tokio::net::TcpStream::connect(addr).await.ok()?;
+        stream
+            .write_all(b"GET / HTTP/1.0\r\nHost: workspace\r\n\r\n")
+            .await
+            .ok()?;
+        let mut buf = [0u8; 1];
+        match stream.read(&mut buf).await {
+            Ok(n) if n > 0 => Some(()),
+            _ => None,
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(2), probe)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -90,5 +138,29 @@ mod tests {
             render_image("cityhall/aoe:latest", "v1"),
             "cityhall/aoe:latest"
         );
+    }
+
+    #[tokio::test]
+    async fn http_probe_requires_a_response_not_just_a_connect() {
+        use tokio::io::AsyncWriteExt;
+
+        // Accepts and answers: ready.
+        let responder = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = responder.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            let (mut sock, _) = responder.accept().await.unwrap();
+            let _ = sock.write_all(b"HTTP/1.0 200 OK\r\n\r\n").await;
+        });
+        assert!(http_probe(&addr).await);
+
+        // Accepts but closes without a byte (docker-proxy with no backend
+        // yet): not ready.
+        let closer = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = closer.local_addr().unwrap().to_string();
+        tokio::spawn(async move {
+            let (sock, _) = closer.accept().await.unwrap();
+            drop(sock);
+        });
+        assert!(!http_probe(&addr).await);
     }
 }

--- a/api/src/orchestrator/process.rs
+++ b/api/src/orchestrator/process.rs
@@ -1,0 +1,401 @@
+//! Bare-process workspace backend for VPS hosts without docker.
+//!
+//! Spawns one detached `aoe serve` per user, with an isolated per-user HOME
+//! directory as the volume equivalent. Versions are per-version binaries the
+//! operator installs under `<root>/versions/<version>/aoe` (from the aoe
+//! release tarball). Runtime state (`state.json` with pid, port, version)
+//! lives next to each user's HOME so workspaces survive CityHall restarts;
+//! the processes themselves are detached into their own session and keep
+//! running when CityHall stops.
+//!
+//! Isolation note: every workspace runs as the CityHall OS user. This backend
+//! provides persistence isolation between users, not security isolation; use
+//! the docker or kubernetes backend where that matters.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    http_probe, wait_ready, Orchestrator, OrchestratorError, WorkspaceSpec, WorkspaceStatus,
+};
+
+/// Grace period between SIGTERM and SIGKILL on stop.
+const STOP_TIMEOUT: Duration = Duration::from_secs(10);
+/// Bind races on the pre-allocated port are rare; one respawn absorbs them.
+const START_ATTEMPTS: u32 = 2;
+
+pub struct ProcessOrchestrator {
+    root: PathBuf,
+}
+
+/// Runtime state persisted across CityHall restarts.
+#[derive(Serialize, Deserialize)]
+struct RunState {
+    pid: i32,
+    port: u16,
+    version: String,
+}
+
+impl ProcessOrchestrator {
+    pub fn from_env() -> Self {
+        ProcessOrchestrator {
+            root: std::env::var("WORKSPACE_PROCESS_DIR")
+                .unwrap_or_else(|_| "/var/lib/cityhall/workspaces".to_string())
+                .into(),
+        }
+    }
+
+    fn user_dir(&self, user_id: i32) -> PathBuf {
+        self.root.join(format!("u{user_id}"))
+    }
+
+    fn state_path(&self, user_id: i32) -> PathBuf {
+        self.user_dir(user_id).join("state.json")
+    }
+
+    fn binary_path(&self, version: &str) -> PathBuf {
+        self.root.join("versions").join(version).join("aoe")
+    }
+
+    fn read_state(&self, user_id: i32) -> Option<RunState> {
+        let raw = std::fs::read_to_string(self.state_path(user_id)).ok()?;
+        match serde_json::from_str(&raw) {
+            Ok(state) => Some(state),
+            Err(e) => {
+                tracing::warn!(user_id, "ignoring unparseable workspace state.json: {e}");
+                None
+            }
+        }
+    }
+
+    fn write_state(&self, user_id: i32, state: &RunState) -> Result<(), OrchestratorError> {
+        let path = self.state_path(user_id);
+        let tmp = path.with_extension("json.tmp");
+        let io = |e: std::io::Error| {
+            OrchestratorError::Runtime(format!("failed to write workspace state: {e}"))
+        };
+        std::fs::write(
+            &tmp,
+            serde_json::to_string(state).expect("state serializes"),
+        )
+        .map_err(io)?;
+        std::fs::rename(&tmp, &path).map_err(io)?;
+        Ok(())
+    }
+
+    /// Spawn a fresh `aoe serve` for `spec`, returning its address. Kills the
+    /// spawn and retries with a new port if it never answers HTTP (e.g. an
+    /// unrelated process stole the pre-allocated port).
+    async fn spawn(&self, spec: &WorkspaceSpec) -> Result<String, OrchestratorError> {
+        let binary = self.binary_path(&spec.version);
+        if !binary.is_file() {
+            return Err(OrchestratorError::ArtifactMissing(format!(
+                "aoe binary for version '{}' not found at {}; install the release \
+                 tarball there (see docs/workspaces.md) or fix the version in the \
+                 workspace settings",
+                spec.version,
+                binary.display()
+            )));
+        }
+        let home = self.user_dir(spec.user_id).join("home");
+        std::fs::create_dir_all(&home).map_err(|e| {
+            OrchestratorError::Runtime(format!("failed to create workspace home: {e}"))
+        })?;
+
+        let mut last_err = None;
+        for _ in 0..START_ATTEMPTS {
+            let port = free_port()?;
+            let addr = format!("127.0.0.1:{port}");
+            let pid = self.spawn_once(spec, &binary, &home, port)?;
+            self.write_state(
+                spec.user_id,
+                &RunState {
+                    pid,
+                    port,
+                    version: spec.version.clone(),
+                },
+            )?;
+            match wait_ready(&addr).await {
+                Ok(()) => return Ok(addr),
+                Err(e) => {
+                    kill_group(pid, libc::SIGKILL);
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(last_err.expect("at least one start attempt"))
+    }
+
+    fn spawn_once(
+        &self,
+        spec: &WorkspaceSpec,
+        binary: &Path,
+        home: &Path,
+        port: u16,
+    ) -> Result<i32, OrchestratorError> {
+        let log = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.user_dir(spec.user_id).join("serve.log"))
+            .map_err(|e| {
+                OrchestratorError::Runtime(format!("failed to open workspace log: {e}"))
+            })?;
+        let mut cmd = std::process::Command::new(binary);
+        cmd.args([
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &port.to_string(),
+            // CityHall's session gates the proxy; the process only listens on
+            // loopback.
+            "--auth",
+            "none",
+            "--behind-proxy",
+        ])
+        .env("HOME", home)
+        .current_dir(home)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(log.try_clone().map_err(|e| {
+            OrchestratorError::Runtime(format!("failed to clone workspace log: {e}"))
+        })?))
+        .stderr(std::process::Stdio::from(log));
+        // Detach into its own session so the workspace survives CityHall
+        // restarts and group signals target only this workspace.
+        unsafe {
+            use std::os::unix::process::CommandExt;
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let child = cmd
+            .spawn()
+            .map_err(|e| OrchestratorError::Runtime(format!("failed to spawn aoe: {e}")))?;
+        Ok(child.id() as i32)
+    }
+
+    /// SIGTERM the workspace's process group, escalating to SIGKILL after the
+    /// grace period.
+    async fn terminate(&self, pid: i32) {
+        kill_group(pid, libc::SIGTERM);
+        let deadline = tokio::time::Instant::now() + STOP_TIMEOUT;
+        while alive(pid) {
+            if tokio::time::Instant::now() >= deadline {
+                kill_group(pid, libc::SIGKILL);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+}
+
+#[async_trait]
+impl Orchestrator for ProcessOrchestrator {
+    async fn ensure_started(&self, spec: &WorkspaceSpec) -> Result<String, OrchestratorError> {
+        validate_version(&spec.version)?;
+        if let Some(state) = self.read_state(spec.user_id) {
+            if alive(state.pid) {
+                let addr = format!("127.0.0.1:{}", state.port);
+                if state.version == spec.version && http_probe(&addr).await {
+                    return Ok(addr);
+                }
+                // Version drift, a hung process, or a recycled PID that is
+                // not our workspace: clear it and start fresh.
+                tracing::info!(
+                    user_id = spec.user_id,
+                    from = %state.version,
+                    to = %spec.version,
+                    "restarting workspace process"
+                );
+                self.terminate(state.pid).await;
+            }
+        }
+        self.spawn(spec).await
+    }
+
+    async fn stop(&self, user_id: i32) -> Result<(), OrchestratorError> {
+        if let Some(state) = self.read_state(user_id) {
+            if alive(state.pid) {
+                self.terminate(state.pid).await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn destroy(&self, user_id: i32) -> Result<(), OrchestratorError> {
+        self.stop(user_id).await?;
+        let dir = self.user_dir(user_id);
+        if dir.exists() {
+            std::fs::remove_dir_all(&dir).map_err(|e| {
+                OrchestratorError::Runtime(format!(
+                    "failed to remove workspace dir {}: {e}",
+                    dir.display()
+                ))
+            })?;
+        }
+        Ok(())
+    }
+
+    async fn status(&self, user_id: i32) -> Result<WorkspaceStatus, OrchestratorError> {
+        match self.read_state(user_id) {
+            None if self.user_dir(user_id).exists() => Ok(WorkspaceStatus::Stopped),
+            None => Ok(WorkspaceStatus::NotCreated),
+            Some(state) if alive(state.pid) => Ok(WorkspaceStatus::Running {
+                addr: format!("127.0.0.1:{}", state.port),
+            }),
+            Some(_) => Ok(WorkspaceStatus::Stopped),
+        }
+    }
+}
+
+/// Versions become path components; reject anything that could escape the
+/// versions directory.
+fn validate_version(version: &str) -> Result<(), OrchestratorError> {
+    let ok = !version.is_empty()
+        && !version.starts_with('.')
+        && version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '+'));
+    if ok {
+        Ok(())
+    } else {
+        Err(OrchestratorError::Runtime(format!(
+            "invalid workspace version '{version}'"
+        )))
+    }
+}
+
+fn alive(pid: i32) -> bool {
+    // Signal 0 probes existence without touching the process.
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+/// Signal the whole process group (setsid makes the pgid the child's pid).
+fn kill_group(pid: i32, signal: i32) {
+    unsafe {
+        libc::kill(-pid, signal);
+    }
+}
+
+/// A currently-free loopback port. The listener is dropped before the spawn,
+/// so a race with an unrelated bind is possible; the caller absorbs it by
+/// probing readiness and retrying with a fresh port.
+fn free_port() -> Result<u16, OrchestratorError> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| OrchestratorError::Runtime(format!("failed to allocate a port: {e}")))?;
+    Ok(listener
+        .local_addr()
+        .map_err(|e| OrchestratorError::Runtime(format!("failed to read allocated port: {e}")))?
+        .port())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> ProcessOrchestrator {
+        let root = std::env::temp_dir().join(format!(
+            "cityhall-process-test-{}-{name}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        ProcessOrchestrator { root }
+    }
+
+    #[test]
+    fn version_validation_blocks_path_escapes() {
+        assert!(validate_version("v0.5.0").is_ok());
+        assert!(validate_version("1.2.3-rc.1+build").is_ok());
+        assert!(validate_version("").is_err());
+        assert!(validate_version("../../etc").is_err());
+        assert!(validate_version("v1/../..").is_err());
+        assert!(validate_version(".hidden").is_err());
+        assert!(validate_version("a b").is_err());
+    }
+
+    #[test]
+    fn state_round_trips_atomically() {
+        let orch = scratch("state");
+        std::fs::create_dir_all(orch.user_dir(7)).unwrap();
+        orch.write_state(
+            7,
+            &RunState {
+                pid: 1234,
+                port: 43210,
+                version: "v1.0.0".to_string(),
+            },
+        )
+        .unwrap();
+        let state = orch.read_state(7).unwrap();
+        assert_eq!(
+            (state.pid, state.port, state.version.as_str()),
+            (1234, 43210, "v1.0.0")
+        );
+        // No leftover temp file from the atomic write.
+        assert!(!orch.state_path(7).with_extension("json.tmp").exists());
+    }
+
+    #[tokio::test]
+    async fn status_reflects_state_file_and_liveness() {
+        let orch = scratch("status");
+        // Nothing on disk: never created.
+        assert_eq!(orch.status(1).await.unwrap(), WorkspaceStatus::NotCreated);
+
+        // Dead pid recorded: stopped. PID 1 is init and never our child, but
+        // a PID that cannot exist is the reliable "dead" case.
+        std::fs::create_dir_all(orch.user_dir(2)).unwrap();
+        orch.write_state(
+            2,
+            &RunState {
+                pid: i32::MAX - 1,
+                port: 1,
+                version: "v1".to_string(),
+            },
+        )
+        .unwrap();
+        assert_eq!(orch.status(2).await.unwrap(), WorkspaceStatus::Stopped);
+
+        // A live pid (this test process): running at the recorded port.
+        std::fs::create_dir_all(orch.user_dir(3)).unwrap();
+        orch.write_state(
+            3,
+            &RunState {
+                pid: std::process::id() as i32,
+                port: 45678,
+                version: "v1".to_string(),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            orch.status(3).await.unwrap(),
+            WorkspaceStatus::Running {
+                addr: "127.0.0.1:45678".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_binary_is_actionable() {
+        let orch = scratch("binary");
+        let spec = WorkspaceSpec {
+            user_id: 9,
+            image: "unused".to_string(),
+            version: "v9.9.9".to_string(),
+        };
+        let err = orch.ensure_started(&spec).await.unwrap_err();
+        match err {
+            OrchestratorError::ArtifactMissing(msg) => {
+                assert!(msg.contains("v9.9.9"));
+                assert!(msg.contains("versions"));
+            }
+            other => panic!("expected ArtifactMissing, got {other:?}"),
+        }
+    }
+}

--- a/api/src/orchestrator/process.rs
+++ b/api/src/orchestrator/process.rs
@@ -13,22 +13,29 @@
 //! the docker or kubernetes backend where that matters.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    http_probe, wait_ready, Orchestrator, OrchestratorError, WorkspaceSpec, WorkspaceStatus,
+    binary_key, http_probe, wait_ready, Begin, Orchestrator, OrchestratorError,
+    ProvisioningRegistry, WorkspaceSpec, WorkspaceStatus,
 };
 
 /// Grace period between SIGTERM and SIGKILL on stop.
 const STOP_TIMEOUT: Duration = Duration::from_secs(10);
 /// Bind races on the pre-allocated port are rare; one respawn absorbs them.
 const START_ATTEMPTS: u32 = 2;
+/// Release tarball downloads legitimately take minutes on slow links.
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
+/// Sanity cap on the release tarball size.
+const MAX_DOWNLOAD_BYTES: u64 = 1024 * 1024 * 1024;
 
 pub struct ProcessOrchestrator {
     root: PathBuf,
+    provisioning: Arc<ProvisioningRegistry>,
 }
 
 /// Runtime state persisted across CityHall restarts.
@@ -40,11 +47,12 @@ struct RunState {
 }
 
 impl ProcessOrchestrator {
-    pub fn from_env() -> Self {
+    pub fn from_env(provisioning: Arc<ProvisioningRegistry>) -> Self {
         ProcessOrchestrator {
             root: std::env::var("WORKSPACE_PROCESS_DIR")
                 .unwrap_or_else(|_| "/var/lib/cityhall/workspaces".to_string())
                 .into(),
+            provisioning,
         }
     }
 
@@ -92,13 +100,7 @@ impl ProcessOrchestrator {
     async fn spawn(&self, spec: &WorkspaceSpec) -> Result<String, OrchestratorError> {
         let binary = self.binary_path(&spec.version);
         if !binary.is_file() {
-            return Err(OrchestratorError::ArtifactMissing(format!(
-                "aoe binary for version '{}' not found at {}; install the release \
-                 tarball there (see docs/workspaces.md) or fix the version in the \
-                 workspace settings",
-                spec.version,
-                binary.display()
-            )));
+            return Err(self.provision_binary(&spec.version, &binary));
         }
         let home = self.user_dir(spec.user_id).join("home");
         std::fs::create_dir_all(&home).map_err(|e| {
@@ -180,6 +182,43 @@ impl ProcessOrchestrator {
         Ok(child.id() as i32)
     }
 
+    /// Kick off (or report) background download of a missing version's aoe
+    /// binary from the GitHub release tarball. Detached from the request so
+    /// a closed tab cannot abort the download mid-flight.
+    fn provision_binary(&self, version: &str, target: &Path) -> OrchestratorError {
+        let key = binary_key(version);
+        let message = format!("downloading aoe {version}");
+        match self.provisioning.begin(&key, &message) {
+            Begin::AlreadyRunning(msg) => OrchestratorError::Provisioning(msg),
+            Begin::RecentlyFailed(msg) => OrchestratorError::ArtifactMissing(msg),
+            Begin::Started => {
+                let registry = self.provisioning.clone();
+                let version = version.to_string();
+                let target = target.to_path_buf();
+                tokio::spawn(async move {
+                    match download_release_binary(&version, &target).await {
+                        Ok(()) => {
+                            tracing::info!(%version, "installed aoe release binary");
+                            registry.succeed(&binary_key(&version));
+                        }
+                        Err(e) => {
+                            tracing::warn!(%version, "aoe binary provisioning failed: {e}");
+                            registry.fail(
+                                &binary_key(&version),
+                                format!(
+                                    "downloading aoe {version} failed: {e}; install the \
+                                     release tarball manually at {} (see docs/workspaces.md)",
+                                    target.display()
+                                ),
+                            );
+                        }
+                    }
+                });
+                OrchestratorError::Provisioning(message)
+            }
+        }
+    }
+
     /// SIGTERM the workspace's process group, escalating to SIGKILL after the
     /// grace period.
     async fn terminate(&self, pid: i32) {
@@ -254,6 +293,111 @@ impl Orchestrator for ProcessOrchestrator {
     }
 }
 
+/// The release tarball's binary name for this host, e.g. `aoe-linux-amd64`.
+fn release_binary_name() -> Result<String, String> {
+    let os = match std::env::consts::OS {
+        "linux" => "linux",
+        "macos" => "darwin",
+        other => return Err(format!("no aoe release binaries for OS '{other}'")),
+    };
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => return Err(format!("no aoe release binaries for arch '{other}'")),
+    };
+    Ok(format!("aoe-{os}-{arch}"))
+}
+
+fn release_tarball_url(version: &str, member: &str) -> String {
+    format!(
+        "https://github.com/agent-of-empires/agent-of-empires/releases/download/{version}/{member}.tar.gz"
+    )
+}
+
+/// Download the release tarball for `version`, extract the single expected
+/// binary, and install it at `target` atomically. The version is validated
+/// by the caller before it reaches a URL or path.
+async fn download_release_binary(version: &str, target: &Path) -> Result<(), String> {
+    use tokio::io::AsyncWriteExt;
+
+    let member = release_binary_name()?;
+    let url = release_tarball_url(version, &member);
+    let dir = target.parent().expect("binary path has a parent");
+    std::fs::create_dir_all(dir).map_err(|e| format!("cannot create versions dir: {e}"))?;
+
+    let client = reqwest::Client::builder()
+        .timeout(DOWNLOAD_TIMEOUT)
+        .build()
+        .map_err(|e| e.to_string())?;
+    let mut resp = client
+        .get(&url)
+        // GitHub's API rejects requests without a User-Agent.
+        .header("User-Agent", "cityhall")
+        .send()
+        .await
+        .map_err(|e| format!("request failed: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("release download failed: {e}"))?;
+    if resp.content_length().unwrap_or(0) > MAX_DOWNLOAD_BYTES {
+        return Err("release tarball is implausibly large".to_string());
+    }
+
+    // Stream to disk; tarballs are tens of megabytes.
+    let tarball = dir.join(format!("{member}.tar.gz.partial"));
+    let mut file = tokio::fs::File::create(&tarball)
+        .await
+        .map_err(|e| format!("cannot write tarball: {e}"))?;
+    let mut written: u64 = 0;
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| format!("download interrupted: {e}"))?
+    {
+        written += chunk.len() as u64;
+        if written > MAX_DOWNLOAD_BYTES {
+            return Err("release tarball is implausibly large".to_string());
+        }
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| format!("cannot write tarball: {e}"))?;
+    }
+    file.flush().await.map_err(|e| e.to_string())?;
+    drop(file);
+
+    // Extract only the expected member; anything else in the archive is
+    // ignored rather than written to disk.
+    let out = tokio::process::Command::new("tar")
+        .arg("-xzf")
+        .arg(&tarball)
+        .arg("-C")
+        .arg(dir)
+        .arg(&member)
+        .output()
+        .await
+        .map_err(|e| format!("failed to run tar: {e}"))?;
+    let _ = std::fs::remove_file(&tarball);
+    if !out.status.success() {
+        return Err(format!(
+            "tar extraction failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+
+    let extracted = dir.join(&member);
+    let meta = std::fs::symlink_metadata(&extracted).map_err(|e| e.to_string())?;
+    if !meta.is_file() {
+        let _ = std::fs::remove_file(&extracted);
+        return Err("release tarball did not contain a regular binary".to_string());
+    }
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&extracted, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| e.to_string())?;
+    }
+    std::fs::rename(&extracted, target).map_err(|e| format!("cannot install binary: {e}"))?;
+    Ok(())
+}
+
 /// Versions become path components; reject anything that could escape the
 /// versions directory.
 fn validate_version(version: &str) -> Result<(), OrchestratorError> {
@@ -306,7 +450,10 @@ mod tests {
         ));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
-        ProcessOrchestrator { root }
+        ProcessOrchestrator {
+            root,
+            provisioning: Arc::default(),
+        }
     }
 
     #[test]
@@ -382,20 +529,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_binary_is_actionable() {
+    async fn missing_binary_reports_provisioning_state() {
         let orch = scratch("binary");
         let spec = WorkspaceSpec {
             user_id: 9,
             image: "unused".to_string(),
             version: "v9.9.9".to_string(),
         };
+        // A recent failed download attempt is surfaced as guidance instead of
+        // re-spawning a download on every request.
+        orch.provisioning.fail(
+            &binary_key("v9.9.9"),
+            "downloading aoe v9.9.9 failed".to_string(),
+        );
         let err = orch.ensure_started(&spec).await.unwrap_err();
         match err {
-            OrchestratorError::ArtifactMissing(msg) => {
-                assert!(msg.contains("v9.9.9"));
-                assert!(msg.contains("versions"));
-            }
+            OrchestratorError::ArtifactMissing(msg) => assert!(msg.contains("v9.9.9")),
             other => panic!("expected ArtifactMissing, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn release_tarball_url_is_versioned() {
+        assert_eq!(
+            release_tarball_url("v1.12.1", "aoe-linux-amd64"),
+            "https://github.com/agent-of-empires/agent-of-empires/releases/download/v1.12.1/aoe-linux-amd64.tar.gz"
+        );
     }
 }

--- a/api/src/proxy.rs
+++ b/api/src/proxy.rs
@@ -72,8 +72,34 @@ async fn handler(State(state): State<AppState>, req: Request<Body>) -> Response<
 async fn proxy(state: AppState, req: Request<Body>) -> Result<Response<Body>, AppError> {
     let (mut parts, body) = req.into_parts();
     let caller = AuthUser::from_request_parts(&mut parts, &state).await?;
-    caller.require("workspaces.use")?;
-    let user_id = caller.user.id;
+
+    if let Some(resp) = admin_access_interception(&parts, &caller)? {
+        return Ok(resp);
+    }
+
+    // Admin access: a valid impersonation cookie routes this browser to the
+    // target user's workspace. Everything downstream (start, activity,
+    // websocket leases) is keyed to the target so their idle accounting
+    // keeps working; the admin's own workspace is untouched.
+    let jar = axum_extra::extract::cookie::CookieJar::from_headers(&parts.headers);
+    let user_id = match jar.get(ADMIN_COOKIE) {
+        Some(cookie) => {
+            let authorized = decode_token(cookie.value(), SESSION_PURPOSE)
+                .filter(|t| t.a == caller.user.id)
+                .filter(|_| caller.require("workspaces.impersonate").is_ok());
+            match authorized {
+                Some(token) => token.t,
+                // Expired, tampered, or revoked: refuse rather than silently
+                // switching this browser back to the admin's own workspace
+                // (the UI would keep looking like the target's).
+                None => return Ok(admin_access_denied()),
+            }
+        }
+        None => {
+            caller.require("workspaces.use")?;
+            caller.user.id
+        }
+    };
 
     // Request-driven start: any hit on the proxy resumes a stopped workspace.
     let addr = workspaces::ensure_started(&state, user_id).await?;
@@ -98,6 +124,170 @@ async fn proxy(state: AppState, req: Request<Body>) -> Result<Response<Body>, Ap
         state.endpoints.invalidate(user_id);
     }
     result
+}
+
+/// Query parameter carrying a freshly minted admin access token.
+pub const ACCESS_PARAM: &str = "cityhall_ws_access";
+/// Query parameter ending admin access (clears the cookie).
+const EXIT_PARAM: &str = "cityhall_ws_exit";
+/// Cookie scoping this browser's proxy requests to another user's workspace.
+const ADMIN_COOKIE: &str = "cityhall_ws_admin";
+const EXCHANGE_PURPOSE: &str = "ws-exchange";
+const SESSION_PURPOSE: &str = "ws-session";
+/// How long a minted access URL stays exchangeable.
+const EXCHANGE_TTL_SECS: i64 = 120;
+/// How long an admin browses the target's workspace before re-opening.
+const SESSION_TTL_SECS: i64 = 30 * 60;
+
+/// Encrypted admin-access token payload (URL and cookie).
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AccessToken {
+    v: u8,
+    /// Purpose: exchange (URL) vs session (cookie), so one cannot stand in
+    /// for the other.
+    p: String,
+    /// The admin's user id; only their session can use the token.
+    a: i32,
+    /// The target user whose workspace is opened.
+    t: i32,
+    /// Unix expiry.
+    exp: i64,
+}
+
+/// Mint the URL token `POST /api/workspaces/{id}/access-url` returns.
+pub fn mint_exchange_token(admin_id: i32, target_id: i32) -> Result<String, AppError> {
+    mint_token(admin_id, target_id, EXCHANGE_PURPOSE, EXCHANGE_TTL_SECS)
+}
+
+fn mint_token(admin_id: i32, target_id: i32, purpose: &str, ttl: i64) -> Result<String, AppError> {
+    let payload = serde_json::to_string(&AccessToken {
+        v: 1,
+        p: purpose.to_string(),
+        a: admin_id,
+        t: target_id,
+        exp: chrono::Utc::now().timestamp() + ttl,
+    })
+    .map_err(|_| AppError::Internal("failed to encode access token"))?;
+    crate::crypto::encrypt(&payload)
+}
+
+/// Decrypt and validate a token; `None` for anything tampered, expired, or
+/// of the wrong purpose (callers respond generically, revealing nothing).
+fn decode_token(raw: &str, purpose: &str) -> Option<AccessToken> {
+    validate_payload(&crate::crypto::decrypt(raw).ok()?, purpose)
+}
+
+fn validate_payload(json: &str, purpose: &str) -> Option<AccessToken> {
+    let token: AccessToken = serde_json::from_str(json).ok()?;
+    (token.v == 1 && token.p == purpose && token.exp > chrono::Utc::now().timestamp())
+        .then_some(token)
+}
+
+/// Handle the admin-access control queries (`cityhall_ws_access` exchange,
+/// `cityhall_ws_exit`) if present. Returns the response to short-circuit
+/// with, or `None` for a normal proxied request.
+fn admin_access_interception(
+    parts: &request::Parts,
+    caller: &AuthUser,
+) -> Result<Option<Response<Body>>, AppError> {
+    let query = parts.uri.query().unwrap_or("");
+    let pairs: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
+        .into_owned()
+        .collect();
+
+    if pairs.iter().any(|(k, _)| k == EXIT_PARAM) {
+        tracing::info!(
+            event = "workspace_admin_access_ended",
+            admin_user_id = caller.user.id,
+            "admin workspace access ended"
+        );
+        return Ok(Some(redirect_without(
+            parts,
+            &pairs,
+            EXIT_PARAM,
+            clear_cookie(),
+        )?));
+    }
+
+    let Some((_, raw)) = pairs.iter().find(|(k, _)| k == ACCESS_PARAM) else {
+        return Ok(None);
+    };
+    let token = decode_token(raw, EXCHANGE_PURPOSE)
+        .filter(|t| t.a == caller.user.id)
+        .ok_or(AppError::Forbidden("invalid or expired access link"))?;
+    caller.require("workspaces.impersonate")?;
+
+    let peer_ip = parts
+        .extensions
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(peer)| peer.ip().to_string());
+    tracing::info!(
+        event = "workspace_admin_access_started",
+        admin_user_id = caller.user.id,
+        admin_username = %caller.user.username,
+        target_user_id = token.t,
+        peer_ip = peer_ip.as_deref().unwrap_or("unknown"),
+        "admin entered another user's workspace"
+    );
+
+    let session = mint_token(token.a, token.t, SESSION_PURPOSE, SESSION_TTL_SECS)?;
+    let secure = parts
+        .headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.eq_ignore_ascii_case("https"));
+    let cookie = format!(
+        "{ADMIN_COOKIE}={session}; HttpOnly; SameSite=Lax; Path=/; Max-Age={SESSION_TTL_SECS}{}",
+        if secure { "; Secure" } else { "" }
+    );
+    Ok(Some(redirect_without(parts, &pairs, ACCESS_PARAM, cookie)?))
+}
+
+/// A 303 to the same URI minus `param` (other query params preserved),
+/// carrying `set_cookie`. Marked uncacheable and referrer-free so the
+/// token-bearing URL leaks nowhere.
+fn redirect_without(
+    parts: &request::Parts,
+    pairs: &[(String, String)],
+    param: &str,
+    set_cookie: String,
+) -> Result<Response<Body>, AppError> {
+    let mut serializer = url::form_urlencoded::Serializer::new(String::new());
+    for (k, v) in pairs.iter().filter(|(k, _)| k != param) {
+        serializer.append_pair(k, v);
+    }
+    let query = serializer.finish();
+    let location = if query.is_empty() {
+        parts.uri.path().to_string()
+    } else {
+        format!("{}?{query}", parts.uri.path())
+    };
+    Response::builder()
+        .status(StatusCode::SEE_OTHER)
+        .header("location", location)
+        .header("set-cookie", set_cookie)
+        .header("cache-control", "no-store")
+        .header("referrer-policy", "no-referrer")
+        .body(Body::empty())
+        .map_err(|_| AppError::Internal("failed to build redirect"))
+}
+
+fn clear_cookie() -> String {
+    format!("{ADMIN_COOKIE}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0")
+}
+
+/// 403 clearing the stale impersonation cookie; the next request is a normal
+/// self-routed one.
+fn admin_access_denied() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::FORBIDDEN)
+        .header("set-cookie", clear_cookie())
+        .header("cache-control", "no-store")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            r#"{"error":"workspace admin access expired or revoked; reload to continue"}"#,
+        ))
+        .unwrap_or_else(|_| StatusCode::FORBIDDEN.into_response())
 }
 
 fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
@@ -285,6 +475,48 @@ mod tests {
         headers.insert(HOST, HeaderValue::from_static("cityhall.local:3000"));
         // No env override in tests; derived from hostname + proxy port.
         assert_eq!(public_origin(&headers), "http://cityhall.local:3001");
+    }
+
+    #[test]
+    fn access_payload_validation() {
+        let fresh = chrono::Utc::now().timestamp() + 60;
+        let ok = format!(r#"{{"v":1,"p":"ws-exchange","a":1,"t":2,"exp":{fresh}}}"#);
+        let token = validate_payload(&ok, EXCHANGE_PURPOSE).unwrap();
+        assert_eq!((token.a, token.t), (1, 2));
+
+        // Purpose confusion: a URL token is not a session cookie.
+        assert!(validate_payload(&ok, SESSION_PURPOSE).is_none());
+        // Expired.
+        let stale = r#"{"v":1,"p":"ws-exchange","a":1,"t":2,"exp":1}"#;
+        assert!(validate_payload(stale, EXCHANGE_PURPOSE).is_none());
+        // Unknown version or garbage.
+        let vnext = format!(r#"{{"v":2,"p":"ws-exchange","a":1,"t":2,"exp":{fresh}}}"#);
+        assert!(validate_payload(&vnext, EXCHANGE_PURPOSE).is_none());
+        assert!(validate_payload("not json", EXCHANGE_PURPOSE).is_none());
+    }
+
+    #[test]
+    fn redirect_strips_only_the_access_param() {
+        let req = Request::builder()
+            .uri("/sessions/abc?cityhall_ws_access=tok&tab=2")
+            .body(Body::empty())
+            .unwrap();
+        let (parts, _) = req.into_parts();
+        let pairs: Vec<(String, String)> =
+            url::form_urlencoded::parse(parts.uri.query().unwrap().as_bytes())
+                .into_owned()
+                .collect();
+        let resp = redirect_without(&parts, &pairs, ACCESS_PARAM, clear_cookie()).unwrap();
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            resp.headers().get("location").unwrap(),
+            "/sessions/abc?tab=2"
+        );
+        assert_eq!(resp.headers().get("cache-control").unwrap(), "no-store");
+        // The stale cookie is cleared on exit.
+        let cookie = resp.headers().get("set-cookie").unwrap().to_str().unwrap();
+        assert!(cookie.starts_with("cityhall_ws_admin=;"));
+        assert!(cookie.contains("Max-Age=0"));
     }
 
     #[test]

--- a/api/src/proxy.rs
+++ b/api/src/proxy.rs
@@ -86,11 +86,18 @@ async fn proxy(state: AppState, req: Request<Body>) -> Result<Response<Body>, Ap
         .unwrap_or("/");
     let target = format!("http://{addr}{path_q}");
 
-    if is_websocket_upgrade(&parts.headers) {
+    let result = if is_websocket_upgrade(&parts.headers) {
         websocket_tunnel(&state, &mut parts, &target, user_id).await
     } else {
         http_forward(&state, &parts, body, &target).await
+    };
+    if result.is_err() {
+        // The workspace may have died out-of-band (crashed container, killed
+        // process): drop the cached address so the next request reconciles
+        // with the backend instead of dialing a dead endpoint forever.
+        state.endpoints.invalidate(user_id);
     }
+    result
 }
 
 fn is_websocket_upgrade(headers: &HeaderMap) -> bool {

--- a/api/src/rbac.rs
+++ b/api/src/rbac.rs
@@ -28,6 +28,10 @@ pub const CATALOG: &[(&str, &str)] = &[
     ("workspaces.use", "Use your own workspace"),
     ("workspaces.read", "View all workspaces"),
     ("workspaces.write", "Manage workspaces and their versions"),
+    (
+        "workspaces.impersonate",
+        "Open other users' workspaces (audited)",
+    ),
 ];
 
 /// Built-in roles seeded on startup: (name, description, permission keys).

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -96,12 +96,14 @@ pub fn build_state(db: DatabaseConnection) -> Result<AppState, Box<dyn std::erro
         .http1_only()
         .redirect(reqwest::redirect::Policy::none())
         .build()?;
+    let (orchestrator, provisioning) = crate::orchestrator::from_env()?;
     Ok(AppState {
         db,
-        orchestrator: crate::orchestrator::from_env()?,
+        orchestrator,
         activity: Arc::default(),
         locks: Arc::default(),
         endpoints: Arc::default(),
+        provisioning,
         proxy_client,
     })
 }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -54,6 +54,10 @@ pub fn api_router(state: AppState) -> Router {
             patch(workspaces::set_version).delete(workspaces::destroy),
         )
         .route("/workspaces/{user_id}/start", post(workspaces::start))
+        .route(
+            "/workspaces/{user_id}/access-url",
+            post(workspaces::access_url),
+        )
         .route("/workspaces/{user_id}/stop", post(workspaces::stop))
         .route("/settings/smtp", get(settings::get).put(settings::update))
         .route("/settings/smtp/test", post(settings::test))

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -101,6 +101,7 @@ pub fn build_state(db: DatabaseConnection) -> Result<AppState, Box<dyn std::erro
         orchestrator: crate::orchestrator::from_env()?,
         activity: Arc::default(),
         locks: Arc::default(),
+        endpoints: Arc::default(),
         proxy_client,
     })
 }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -10,7 +10,6 @@ use tower_http::trace::TraceLayer;
 
 use crate::error::AppError;
 use crate::handlers::{auth, oidc, roles, settings, signup, users, workspaces};
-use crate::orchestrator::docker::DockerCliOrchestrator;
 use crate::proxy;
 use crate::state::AppState;
 
@@ -99,7 +98,7 @@ pub fn build_state(db: DatabaseConnection) -> Result<AppState, Box<dyn std::erro
         .build()?;
     Ok(AppState {
         db,
-        orchestrator: Arc::new(DockerCliOrchestrator::from_env()),
+        orchestrator: crate::orchestrator::from_env()?,
         activity: Arc::default(),
         locks: Arc::default(),
         proxy_client,

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -48,6 +48,7 @@ pub fn api_router(state: AppState) -> Router {
             get(workspaces::list).patch(workspaces::bulk_set_version),
         )
         .route("/workspaces/me", get(workspaces::me))
+        .route("/workspaces/versions", get(workspaces::versions))
         .route(
             "/workspaces/{user_id}",
             patch(workspaces::set_version).delete(workspaces::destroy),
@@ -104,6 +105,7 @@ pub fn build_state(db: DatabaseConnection) -> Result<AppState, Box<dyn std::erro
         locks: Arc::default(),
         endpoints: Arc::default(),
         provisioning,
+        versions: Arc::default(),
         proxy_client,
     })
 }

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -19,6 +19,8 @@ pub struct AppState {
     /// Read side of background artifact provisioning (pulls, builds,
     /// downloads); the backends write to it.
     pub provisioning: Arc<ProvisioningRegistry>,
+    /// Cached aoe release discovery feeding the version dropdowns.
+    pub versions: Arc<crate::workspaces::VersionCache>,
     /// Client for proxied HTTP requests to workspaces (no redirects, HTTP/1.1
     /// so WebSocket upgrades tunnel through).
     pub proxy_client: reqwest::Client,

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use axum::extract::FromRef;
 use sea_orm::DatabaseConnection;
 
-use crate::orchestrator::Orchestrator;
+use crate::orchestrator::{Orchestrator, ProvisioningRegistry};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -16,6 +16,9 @@ pub struct AppState {
     pub activity: Arc<ActivityRegistry>,
     pub locks: Arc<WorkspaceLocks>,
     pub endpoints: Arc<EndpointCache>,
+    /// Read side of background artifact provisioning (pulls, builds,
+    /// downloads); the backends write to it.
+    pub provisioning: Arc<ProvisioningRegistry>,
     /// Client for proxied HTTP requests to workspaces (no redirects, HTTP/1.1
     /// so WebSocket upgrades tunnel through).
     pub proxy_client: reqwest::Client,

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -15,6 +15,7 @@ pub struct AppState {
     pub orchestrator: Arc<dyn Orchestrator>,
     pub activity: Arc<ActivityRegistry>,
     pub locks: Arc<WorkspaceLocks>,
+    pub endpoints: Arc<EndpointCache>,
     /// Client for proxied HTTP requests to workspaces (no redirects, HTTP/1.1
     /// so WebSocket upgrades tunnel through).
     pub proxy_client: reqwest::Client,
@@ -76,6 +77,52 @@ impl ActivityRegistry {
     }
 }
 
+/// Per-user cache of the reachable workspace address, keyed by the spec that
+/// produced it. Without it every proxied request (each asset, each API call)
+/// pays a backend round-trip (docker/kubectl shell-outs); with it only the
+/// first request after a start, stop, or failure reconciles. Stop and destroy
+/// invalidate; a failed proxied dial invalidates so the next request heals
+/// out-of-band crashes.
+#[derive(Default)]
+pub struct EndpointCache {
+    entries: Mutex<HashMap<i32, CachedEndpoint>>,
+}
+
+#[derive(Clone)]
+struct CachedEndpoint {
+    addr: String,
+    version: String,
+    image: String,
+}
+
+impl EndpointCache {
+    /// The cached address, if it was produced by a spec with the same version
+    /// and image (a pin or template change must miss and reconcile).
+    pub fn get(&self, user_id: i32, version: &str, image: &str) -> Option<String> {
+        self.entries
+            .lock()
+            .unwrap()
+            .get(&user_id)
+            .filter(|e| e.version == version && e.image == image)
+            .map(|e| e.addr.clone())
+    }
+
+    pub fn put(&self, user_id: i32, version: &str, image: &str, addr: String) {
+        self.entries.lock().unwrap().insert(
+            user_id,
+            CachedEndpoint {
+                addr,
+                version: version.to_string(),
+                image: image.to_string(),
+            },
+        );
+    }
+
+    pub fn invalidate(&self, user_id: i32) {
+        self.entries.lock().unwrap().remove(&user_id);
+    }
+}
+
 /// Per-user async locks serializing workspace lifecycle transitions, so a
 /// proxy-triggered start cannot race the idle sweeper's stop (or a concurrent
 /// first-page-load double-start).
@@ -117,5 +164,23 @@ mod tests {
     fn unknown_user_has_no_entry() {
         let reg = ActivityRegistry::default();
         assert!(reg.get(99).is_none());
+    }
+
+    #[test]
+    fn endpoint_cache_hits_only_on_matching_spec() {
+        let cache = EndpointCache::default();
+        assert!(cache.get(1, "v1", "img:v1").is_none());
+
+        cache.put(1, "v1", "img:v1", "127.0.0.1:5000".to_string());
+        assert_eq!(
+            cache.get(1, "v1", "img:v1").as_deref(),
+            Some("127.0.0.1:5000")
+        );
+        // A version pin or template change must miss and reconcile.
+        assert!(cache.get(1, "v2", "img:v2").is_none());
+        assert!(cache.get(1, "v1", "other:v1").is_none());
+
+        cache.invalidate(1);
+        assert!(cache.get(1, "v1", "img:v1").is_none());
     }
 }

--- a/api/src/workspaces.rs
+++ b/api/src/workspaces.rs
@@ -40,8 +40,12 @@ pub async fn seed_default_version(db: &DatabaseConnection) -> Result<(), AppErro
     {
         return Ok(());
     }
-    let version = match fetch_latest_release().await {
-        Ok(tag) => tag,
+    let version = match fetch_releases().await.map(|v| v.into_iter().next()) {
+        Ok(Some(tag)) => tag,
+        Ok(None) => {
+            tracing::warn!("no aoe releases found to seed the default workspace version");
+            return Ok(());
+        }
         Err(e) => {
             tracing::warn!(
                 "could not resolve the latest aoe release for the default workspace version: {e}"
@@ -67,20 +71,25 @@ async fn apply_seeded_version(db: &DatabaseConnection, version: String) -> Resul
     Ok(())
 }
 
-/// The `tag_name` of the latest agent-of-empires GitHub release.
-async fn fetch_latest_release() -> Result<String, String> {
-    #[derive(serde::Deserialize)]
-    struct Release {
-        tag_name: String,
-    }
+/// Stable (non-draft, non-prerelease) agent-of-empires release tags, newest
+/// first by version.
+async fn fetch_releases() -> Result<Vec<String>, String> {
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(10))
         .build()
         .map_err(|e| e.to_string())?;
-    let body = client
-        .get("https://api.github.com/repos/agent-of-empires/agent-of-empires/releases/latest")
+    let mut req = client
+        .get("https://api.github.com/repos/agent-of-empires/agent-of-empires/releases?per_page=100")
         // GitHub's API rejects requests without a User-Agent.
-        .header("User-Agent", "cityhall")
+        .header("User-Agent", "cityhall");
+    // Optional: authenticated requests get a much higher rate limit (the
+    // unauthenticated 60/h is shared per source IP).
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        if !token.trim().is_empty() {
+            req = req.header("Authorization", format!("Bearer {}", token.trim()));
+        }
+    }
+    let body = req
         .send()
         .await
         .map_err(|e| e.to_string())?
@@ -89,8 +98,90 @@ async fn fetch_latest_release() -> Result<String, String> {
         .text()
         .await
         .map_err(|e| e.to_string())?;
-    let release: Release = serde_json::from_str(&body).map_err(|e| e.to_string())?;
-    Ok(release.tag_name)
+    parse_releases(&body).map_err(|e| e.to_string())
+}
+
+/// Parse the GitHub releases payload into stable tags, newest version first.
+/// GitHub orders by creation date, which misplaces backported patches
+/// (v1.0.1 released after v2.0.0 would come first).
+fn parse_releases(body: &str) -> Result<Vec<String>, serde_json::Error> {
+    #[derive(serde::Deserialize)]
+    struct Release {
+        tag_name: String,
+        draft: bool,
+        prerelease: bool,
+    }
+    let releases: Vec<Release> = serde_json::from_str(body)?;
+    let mut tags: Vec<String> = releases
+        .into_iter()
+        .filter(|r| !r.draft && !r.prerelease)
+        .map(|r| r.tag_name)
+        .collect();
+    tags.sort_by_key(|t| std::cmp::Reverse(version_key(t)));
+    Ok(tags)
+}
+
+/// Numeric components of a version tag ("v1.10.2" -> [1, 10, 2]) for
+/// ordering; tags without digits compare as empty (never "outdated").
+pub fn version_key(tag: &str) -> Vec<u64> {
+    tag.split(|c: char| !c.is_ascii_digit())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.parse().unwrap_or(u64::MAX))
+        .collect()
+}
+
+/// Cached release discovery: single-flight refresh, 1h TTL, and
+/// stale-on-error so a GitHub outage degrades to the last known list
+/// instead of an empty dropdown.
+#[derive(Default)]
+pub struct VersionCache {
+    /// Serializes refreshes so concurrent cache misses produce one request.
+    refresh: tokio::sync::Mutex<()>,
+    state: std::sync::Mutex<VersionCacheState>,
+}
+
+#[derive(Default)]
+struct VersionCacheState {
+    fetched_at: Option<tokio::time::Instant>,
+    versions: Vec<String>,
+}
+
+const VERSION_CACHE_TTL: Duration = Duration::from_secs(3600);
+
+impl VersionCache {
+    /// The cached (or freshly fetched) release tags and whether they are
+    /// stale (a refresh failed and an older list is being served).
+    pub async fn versions(&self) -> (Vec<String>, bool) {
+        if let Some(fresh) = self.fresh() {
+            return (fresh, false);
+        }
+        let _refresh = self.refresh.lock().await;
+        // Another caller may have refreshed while this one waited.
+        if let Some(fresh) = self.fresh() {
+            return (fresh, false);
+        }
+        match fetch_releases().await {
+            Ok(versions) => {
+                let mut state = self.state.lock().unwrap();
+                state.fetched_at = Some(tokio::time::Instant::now());
+                state.versions = versions.clone();
+                (versions, false)
+            }
+            Err(e) => {
+                tracing::warn!("release discovery failed, serving the last known list: {e}");
+                let state = self.state.lock().unwrap();
+                (state.versions.clone(), true)
+            }
+        }
+    }
+
+    fn fresh(&self) -> Option<Vec<String>> {
+        let state = self.state.lock().unwrap();
+        state
+            .fetched_at
+            .filter(|at| at.elapsed() < VERSION_CACHE_TTL)
+            .map(|_| state.versions.clone())
+    }
 }
 
 /// The user's workspace intent row, created on first use.
@@ -334,6 +425,28 @@ mod tests {
 
         seed_default_version(&db).await.unwrap();
         assert_eq!(settings(&db).await.unwrap().default_version, None);
+    }
+
+    #[test]
+    fn version_keys_order_numerically() {
+        assert!(version_key("v1.10.0") > version_key("v1.9.9"));
+        assert!(version_key("v2.0.0") > version_key("v1.99.99"));
+        assert_eq!(version_key("1.2.3"), version_key("v1.2.3"));
+        // Non-numeric tags compare as empty: never flagged outdated.
+        assert!(version_key("custom-build").is_empty());
+    }
+
+    #[test]
+    fn release_parsing_filters_and_sorts() {
+        let body = r#"[
+            {"tag_name": "v1.9.0", "draft": false, "prerelease": false},
+            {"tag_name": "v2.0.0-rc.1", "draft": false, "prerelease": true},
+            {"tag_name": "v1.10.0", "draft": false, "prerelease": false},
+            {"tag_name": "v3.0.0", "draft": true, "prerelease": false}
+        ]"#;
+        // Drafts and prereleases are dropped; order is by version, not the
+        // API's creation-date order.
+        assert_eq!(parse_releases(body).unwrap(), vec!["v1.10.0", "v1.9.0"]);
     }
 
     #[tokio::test]

--- a/api/src/workspaces.rs
+++ b/api/src/workspaces.rs
@@ -151,9 +151,23 @@ pub async fn ensure_started(state: &AppState, user_id: i32) -> Result<String, Ap
     let row = get_or_create(&state.db, user_id).await?;
     let spec = build_spec(&cfg, &row)?;
 
+    // Hot path: a cached address means no backend round-trip per request.
+    if let Some(addr) = state.endpoints.get(user_id, &spec.version, &spec.image) {
+        state.activity.touch(user_id);
+        return Ok(addr);
+    }
+
     let lock = state.locks.lock_for(user_id);
     let _guard = lock.lock().await;
+    // Re-check under the lock: a concurrent request may have reconciled.
+    if let Some(addr) = state.endpoints.get(user_id, &spec.version, &spec.image) {
+        state.activity.touch(user_id);
+        return Ok(addr);
+    }
     let addr = state.orchestrator.ensure_started(&spec).await?;
+    state
+        .endpoints
+        .put(user_id, &spec.version, &spec.image, addr.clone());
     state.activity.touch(user_id);
     Ok(addr)
 }
@@ -162,6 +176,7 @@ pub async fn ensure_started(state: &AppState, user_id: i32) -> Result<String, Ap
 pub async fn stop(state: &AppState, user_id: i32) -> Result<(), AppError> {
     let lock = state.locks.lock_for(user_id);
     let _guard = lock.lock().await;
+    state.endpoints.invalidate(user_id);
     state.orchestrator.stop(user_id).await?;
     checkpoint_activity(state, user_id).await
 }
@@ -170,6 +185,7 @@ pub async fn stop(state: &AppState, user_id: i32) -> Result<(), AppError> {
 pub async fn destroy(state: &AppState, user_id: i32) -> Result<(), AppError> {
     let lock = state.locks.lock_for(user_id);
     let _guard = lock.lock().await;
+    state.endpoints.invalidate(user_id);
     state.orchestrator.destroy(user_id).await?;
     workspace::Entity::delete_by_id(user_id)
         .exec(&state.db)
@@ -248,6 +264,7 @@ async fn sweep_once(state: &AppState) -> Result<(), AppError> {
                     state.orchestrator.status(user_id).await
                 {
                     tracing::info!(user_id, "stopping idle workspace");
+                    state.endpoints.invalidate(user_id);
                     if let Err(e) = state.orchestrator.stop(user_id).await {
                         tracing::warn!(user_id, "idle stop failed: {e}");
                         continue;

--- a/api/src/workspaces.rs
+++ b/api/src/workspaces.rs
@@ -266,6 +266,36 @@ pub async fn ensure_started(state: &AppState, user_id: i32) -> Result<String, Ap
     Ok(addr)
 }
 
+/// Recreate a RUNNING workspace onto its current effective spec (admin
+/// version rollout). Deliberately does not touch activity: a rollout must
+/// not grant idle workspaces a fresh idle-stop lease. Stopped workspaces are
+/// left stopped; they pick the new version up on their next start.
+pub async fn restart_if_running(state: &AppState, user_id: i32) -> Result<(), AppError> {
+    let cfg = settings(&state.db).await?;
+    let Some(row) = workspace::Entity::find_by_id(user_id)
+        .one(&state.db)
+        .await?
+    else {
+        return Ok(());
+    };
+    let spec = build_spec(&cfg, &row)?;
+
+    let lock = state.locks.lock_for(user_id);
+    let _guard = lock.lock().await;
+    if !matches!(
+        state.orchestrator.status(user_id).await,
+        Ok(WorkspaceStatus::Running { .. })
+    ) {
+        return Ok(());
+    }
+    state.endpoints.invalidate(user_id);
+    let addr = state.orchestrator.ensure_started(&spec).await?;
+    state
+        .endpoints
+        .put(user_id, &spec.version, &spec.image, addr);
+    Ok(())
+}
+
 /// Stop the workspace (volume kept), checkpointing the activity time.
 pub async fn stop(state: &AppState, user_id: i32) -> Result<(), AppError> {
     let lock = state.locks.lock_for(user_id);

--- a/api/src/workspaces.rs
+++ b/api/src/workspaces.rs
@@ -139,7 +139,10 @@ pub fn build_spec(
 
 impl From<OrchestratorError> for AppError {
     fn from(e: OrchestratorError) -> Self {
-        AppError::WorkspaceUnavailable(e.to_string())
+        match e {
+            OrchestratorError::Provisioning(m) => AppError::WorkspaceProvisioning(m),
+            other => AppError::WorkspaceUnavailable(other.to_string()),
+        }
     }
 }
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -6,13 +6,14 @@ Copy-paste starting points for running CityHall in production. Full walkthrough:
 | Path | What it is |
 | ---- | ---------- |
 | `docker-compose.prod.yml` | CityHall + Postgres + Caddy (automatic HTTPS). The simplest self-host. |
+| `docker-compose.workspaces.yml` | Overlay enabling per-user aoe workspaces for the Compose stack (socket mount + shared network). |
 | `.env.example` | Variables for the Compose stack. Copy to `.env`. |
 | `reverse-proxy/Caddyfile` | Caddy config (used by the Compose stack). |
 | `reverse-proxy/nginx.conf` | nginx TLS termination for a single host. |
 | `reverse-proxy/docker-compose.traefik.yml` | Traefik edge with automatic HTTPS via labels. |
 | `systemd/cityhall.service` | Run the binary on a bare VPS under systemd. |
 | `systemd/cityhall.env.example` | Config for the systemd unit (`/etc/cityhall.env`). |
-| `k8s/` | Kustomize bundle: namespace, secret, Postgres, deployment, service, ingress. |
+| `k8s/` | Kustomize bundle: namespace, secret, Postgres, deployment, service, ingress, workspace RBAC + NetworkPolicy. |
 | `helm/cityhall/` | Helm chart: the same resources, templated with a `values.yaml`. |
 
 Quick starts:

--- a/deploy/docker-compose.workspaces.yml
+++ b/deploy/docker-compose.workspaces.yml
@@ -1,0 +1,33 @@
+# Overlay enabling per-user aoe workspaces when CityHall itself runs in
+# compose. Combine with the base stack:
+#
+#   docker compose -f docker-compose.prod.yml -f docker-compose.workspaces.yml up -d --build
+#
+# CityHall gets the docker socket and a dedicated network shared with the
+# workspace containers it spawns; workspaces publish no ports and are dialed
+# by container DNS (WORKSPACE_DOCKER_NETWORK).
+#
+# Expose the workspace proxy (port 3001) through your reverse proxy as a
+# second origin and set WORKSPACE_PROXY_PUBLIC_ORIGIN accordingly; see the
+# commented block in reverse-proxy/Caddyfile and docs/workspaces.md.
+
+services:
+  cityhall:
+    environment:
+      WORKSPACE_BACKEND: docker
+      WORKSPACE_DOCKER_NETWORK: cityhall-workspaces
+      WORKSPACE_PROXY_BIND_ADDR: 0.0.0.0:3001
+      # The public origin browsers use for workspaces, e.g. https://ws.example.com
+      WORKSPACE_PROXY_PUBLIC_ORIGIN: "${WORKSPACE_PROXY_PUBLIC_ORIGIN:?set WORKSPACE_PROXY_PUBLIC_ORIGIN in .env}"
+    volumes:
+      # Full control of the host's docker daemon: treat CityHall as root on
+      # this host, or point this at a restricted docker socket proxy.
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - default
+      - cityhall-workspaces
+
+networks:
+  cityhall-workspaces:
+    # Fixed name: CityHall passes this exact name to `docker run --network`.
+    name: cityhall-workspaces

--- a/deploy/helm/cityhall/templates/deployment.yaml
+++ b/deploy/helm/cityhall/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels:
         {{- include "cityhall.selector" . | nindent 8 }}
     spec:
+      {{- if .Values.workspaces.enabled }}
+      serviceAccountName: {{ .Release.Name }}
+      {{- end }}
       containers:
         - name: cityhall
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -21,6 +24,16 @@ spec:
           env:
             - name: BIND_ADDR
               value: "0.0.0.0:3000"
+            {{- if .Values.workspaces.enabled }}
+            - name: WORKSPACE_BACKEND
+              value: kubernetes
+            - name: WORKSPACE_K8S_VOLUME_SIZE
+              value: {{ .Values.workspaces.volumeSize | quote }}
+            {{- if .Values.workspaces.storageClass }}
+            - name: WORKSPACE_K8S_STORAGE_CLASS
+              value: {{ .Values.workspaces.storageClass | quote }}
+            {{- end }}
+            {{- end }}
             {{- range $k, $v := .Values.config.extraEnv }}
             - name: {{ $k }}
               value: {{ $v | quote }}

--- a/deploy/helm/cityhall/templates/workspaces-networkpolicy.yaml
+++ b/deploy/helm/cityhall/templates/workspaces-networkpolicy.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.workspaces.enabled }}
+# Workspace pods run `aoe serve --auth none`; CityHall's session-gated proxy
+# is the only auth boundary. This policy keeps every other pod in the cluster
+# away from them. Enforcement requires a CNI with NetworkPolicy support.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-workspaces
+  labels:
+    {{- include "cityhall.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      cityhall.managed: "true"
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "cityhall.selector" . | nindent 14 }}
+      ports:
+        - port: 8080
+{{- end }}

--- a/deploy/helm/cityhall/templates/workspaces-rbac.yaml
+++ b/deploy/helm/cityhall/templates/workspaces-rbac.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.workspaces.enabled }}
+# Lets CityHall manage per-user workspace objects (Deployment + Service +
+# PVC, plus reading pod status) via the kubernetes workspace backend.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "cityhall.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-workspaces
+  labels:
+    {{- include "cityhall.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "create", "patch", "update", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["services", "persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-workspaces
+  labels:
+    {{- include "cityhall.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-workspaces
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/cityhall/values.yaml
+++ b/deploy/helm/cityhall/values.yaml
@@ -33,6 +33,16 @@ postgres:
 service:
   port: 80
 
+# Per-user aoe workspaces on the kubernetes backend: one Deployment + Service
+# + PVC per user in the release namespace, managed by CityHall through a
+# namespace-scoped Role (see templates/workspaces-rbac.yaml).
+workspaces:
+  enabled: true
+  # PVC size per workspace.
+  volumeSize: 5Gi
+  # Storage class for workspace PVCs; empty uses the cluster default.
+  storageClass: ""
+
 ingress:
   enabled: true
   className: nginx

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         app: cityhall
     spec:
+      # Grants the workspace backend its Deployment/Service/PVC permissions
+      # (workspaces-rbac.yaml).
+      serviceAccountName: cityhall
       containers:
         - name: cityhall
           # Replace with your pushed registry path, e.g.
@@ -21,6 +24,8 @@ spec:
           env:
             - name: BIND_ADDR
               value: 0.0.0.0:3000
+            - name: WORKSPACE_BACKEND
+              value: kubernetes
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - workspaces-rbac.yaml
+  - workspaces-networkpolicy.yaml

--- a/deploy/k8s/workspaces-networkpolicy.yaml
+++ b/deploy/k8s/workspaces-networkpolicy.yaml
@@ -1,0 +1,21 @@
+# Workspace pods run `aoe serve --auth none`; CityHall's session-gated proxy
+# is the only auth boundary. This policy keeps every other pod in the cluster
+# away from them. Enforcement requires a CNI with NetworkPolicy support.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cityhall-workspaces
+  namespace: cityhall
+spec:
+  podSelector:
+    matchLabels:
+      cityhall.managed: "true"
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: cityhall
+      ports:
+        - port: 8080

--- a/deploy/k8s/workspaces-rbac.yaml
+++ b/deploy/k8s/workspaces-rbac.yaml
@@ -1,0 +1,41 @@
+# Lets CityHall manage per-user workspace objects (Deployment + Service +
+# PVC, plus reading pod status) in its namespace via the kubernetes workspace
+# backend (WORKSPACE_BACKEND=kubernetes).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cityhall
+  namespace: cityhall
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cityhall-workspaces
+  namespace: cityhall
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "create", "patch", "update", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["services", "persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cityhall-workspaces
+  namespace: cityhall
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cityhall-workspaces
+subjects:
+  - kind: ServiceAccount
+    name: cityhall
+    namespace: cityhall

--- a/deploy/reverse-proxy/Caddyfile
+++ b/deploy/reverse-proxy/Caddyfile
@@ -10,3 +10,10 @@
 	# Caddy sets X-Forwarded-Proto/-For/Host automatically.
 	reverse_proxy cityhall:3000
 }
+
+# Workspace proxy origin (uncomment when using docker-compose.workspaces.yml).
+# Point WORKSPACE_PROXY_PUBLIC_ORIGIN at this hostname; WebSockets proxy
+# through automatically.
+#ws.{$CITYHALL_DOMAIN} {
+#	reverse_proxy cityhall:3001
+#}

--- a/deploy/systemd/cityhall.env.example
+++ b/deploy/systemd/cityhall.env.example
@@ -16,3 +16,13 @@ CITYHALL_BASE_URL=https://cityhall.example.com
 
 # Encrypts stored SMTP/OIDC secrets. Generate once: openssl rand -base64 32
 CITYHALL_SECRET_KEY=change-me-base64-32-bytes
+
+# Per-user aoe workspaces without docker: the bare-process backend spawns one
+# detached `aoe serve` per user under WORKSPACE_PROCESS_DIR. Install each
+# served version's binary at $WORKSPACE_PROCESS_DIR/versions/<version>/aoe
+# (from the aoe release tarball). See docs/workspaces.md.
+#WORKSPACE_BACKEND=process
+#WORKSPACE_PROCESS_DIR=/var/lib/cityhall/workspaces
+# Expose the workspace proxy through the reverse proxy as a second origin.
+#WORKSPACE_PROXY_BIND_ADDR=127.0.0.1:3001
+#WORKSPACE_PROXY_PUBLIC_ORIGIN=https://ws.cityhall.example.com

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,13 @@ Docker, Compose, or Kubernetes deployment without a config file.
 | `OIDC_ALLOWED_DOMAINS` | _(any)_                   | Comma-separated email domains allowed to auto-provision. |
 | `WORKSPACE_PROXY_BIND_ADDR` | `127.0.0.1:3001`     | Workspace proxy listener (see [Workspaces](workspaces.md)). |
 | `WORKSPACE_PROXY_PUBLIC_ORIGIN` | _(derived)_      | Public origin of the workspace proxy behind a reverse proxy. |
-| `CONTAINER_CLI` | `docker`                         | Container CLI used to manage workspaces (e.g. `podman`). |
+| `WORKSPACE_BACKEND` | `docker`                     | Workspace backend: `docker`, `kubernetes`, or `process`. |
+| `CONTAINER_CLI` | `docker`                         | Container CLI used by the docker backend (e.g. `podman`). |
+| `WORKSPACE_DOCKER_NETWORK` | _(unset)_             | Docker network workspaces join (no published ports); for CityHall-in-compose. |
+| `WORKSPACE_K8S_NAMESPACE` | _(pod namespace)_      | Namespace workspace objects are created in. |
+| `WORKSPACE_K8S_VOLUME_SIZE` | `5Gi`                | PVC size per workspace. |
+| `WORKSPACE_K8S_STORAGE_CLASS` | _(cluster default)_ | Storage class for workspace PVCs. |
+| `WORKSPACE_PROCESS_DIR` | `/var/lib/cityhall/workspaces` | Data root of the process backend (per-user HOMEs, version binaries). |
 
 ## Database
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ Docker, Compose, or Kubernetes deployment without a config file.
 | `WORKSPACE_K8S_VOLUME_SIZE` | `5Gi`                | PVC size per workspace. |
 | `WORKSPACE_K8S_STORAGE_CLASS` | _(cluster default)_ | Storage class for workspace PVCs. |
 | `WORKSPACE_PROCESS_DIR` | `/var/lib/cityhall/workspaces` | Data root of the process backend (per-user HOMEs, version binaries). |
+| `GITHUB_TOKEN`  | _(unset)_                        | Authenticates aoe release discovery (higher GitHub rate limit). |
 
 ## Database
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -94,6 +94,11 @@ are exposed.
 Data lives in named volumes (`pgdata`, `caddy_data`); they survive
 `docker compose down`. Use `down -v` only when you intend to wipe everything.
 
+To run per-user aoe workspaces from this stack, add the
+[`deploy/docker-compose.workspaces.yml`](../deploy/docker-compose.workspaces.yml)
+overlay (docker socket mount + shared workspace network) and expose the
+workspace proxy as a second origin; see [Workspaces](workspaces.md#backends).
+
 ## Kubernetes
 
 [`deploy/k8s/`](../deploy/k8s) is a minimal Kustomize bundle: a namespace, a

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,10 +1,10 @@
 # Workspaces
 
 A workspace is one long-lived [aoe](https://github.com/agent-of-empires/agent-of-empires)
-instance per user, spawned and managed by CityHall (docker containers today;
-the orchestration seam is backend-agnostic). Each workspace has a persistent
-data volume, so aoe sessions and configuration survive stops, restarts, and
-version changes.
+instance per user, spawned and managed by CityHall (docker containers by
+default; kubernetes and bare-process backends are available, see
+[Backends](#backends)). Each workspace has a persistent data volume, so aoe
+sessions and configuration survive stops, restarts, and version changes.
 
 ## How it works
 
@@ -64,14 +64,36 @@ host. WebSocket upgrade forwarding must be enabled on the external proxy.
 | -------- | ------- | ------- |
 | `WORKSPACE_PROXY_BIND_ADDR` | `127.0.0.1:3001` | Address of the workspace proxy listener. |
 | `WORKSPACE_PROXY_PUBLIC_ORIGIN` | _(derived)_ | Public origin browsers use to reach the proxy. |
-| `CONTAINER_CLI` | `docker` | Container CLI binary (e.g. `podman`). |
+
+## Backends
+
+`WORKSPACE_BACKEND` selects how workspaces run (see
+[Configuration](configuration.md) for every variable):
+
+- **`docker`** (default). One container + named volume per user. CityHall on
+  the docker host dials loopback-published ports; with
+  `WORKSPACE_DOCKER_NETWORK` set, workspaces instead join that docker network
+  with no published ports and are dialed by container DNS, which is how
+  CityHall itself runs in docker/compose (socket mounted, see
+  `deploy/docker-compose.workspaces.yml`). Mounting the docker socket gives
+  CityHall effective root on the host; use a restricted socket proxy if that
+  matters.
+- **`kubernetes`**. One Deployment + Service + PVC per user, managed with
+  `kubectl` in the CityHall pod's namespace (override with
+  `WORKSPACE_K8S_NAMESPACE`). Stop scales to zero keeping the PVC; destroy
+  deletes all three. The image template must point at a registry the cluster
+  can pull. Requires the RBAC and NetworkPolicy shipped in `deploy/k8s/` and
+  the helm chart; without the NetworkPolicy any pod in the cluster can reach
+  the auth-none workspaces.
+- **`process`** (unix). One detached `aoe serve` per user with an isolated
+  HOME under `WORKSPACE_PROCESS_DIR`, for VPS hosts without docker. Install
+  each served version's binary at
+  `$WORKSPACE_PROCESS_DIR/versions/<version>/aoe` (from the aoe release
+  tarball). Processes survive CityHall restarts. This isolates data, not
+  security: every workspace runs as the CityHall OS user.
 
 ## Current limitations
 
-- CityHall must run natively on the docker host (the backend dials
-  loopback-published ports). CityHall-in-docker/compose/kubernetes topologies
-  and non-docker backends are tracked in
-  [#18](https://github.com/agent-of-empires/cityhall/issues/18).
 - Workspace images are operator-built ([#17](https://github.com/agent-of-empires/cityhall/issues/17)
   tracks auto-pull/build).
 - Agent credentials are not forwarded into workspaces yet

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -42,10 +42,13 @@ registry:
 docker build --build-arg AOE_VERSION=v0.5.0 -t cityhall/aoe:v0.5.0 deploy/aoe-image/
 ```
 
-On a first startup the default version is pre-filled with the latest aoe
-release (skipped when offline); adjust it under **Settings → Workspaces** if
-needed. Starting a workspace with no default version set fails with a
-descriptive error.
+Version fields offer the discovered stable aoe releases, fetched from the
+GitHub API and cached for an hour (the last known list is served when GitHub
+is unreachable; set `GITHUB_TOKEN` if the unauthenticated per-IP rate limit
+is a problem). On a first startup the default version is pre-filled with the
+latest release (skipped when offline); adjust it under **Settings →
+Workspaces** if needed. Starting a workspace with no default version set
+fails with a descriptive error.
 
 Members hold the `workspaces.use` permission by default and can open their own
 workspace. `workspaces.read` / `workspaces.write` gate the admin Workspaces

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -25,9 +25,18 @@ sessions and configuration survive stops, restarts, and version changes.
 
 ## Setup
 
-Workspaces are always on; the only required setup is the image. Build the
-workspace image for the version you want to serve (no official aoe server
-image is published yet):
+Workspaces are always on and provision themselves. On the docker backend a
+missing image is pulled from the registry the image template points at, and
+when that fails (the default `cityhall/aoe:{version}` template is not a
+published image) it is built locally from the reference Dockerfile; on the
+process backend a missing binary is downloaded from the version's release
+tarball. The first start of a new version therefore takes a few minutes; the
+admin Workspaces page shows the progress, and requests get a retry-shortly
+error until the artifact is ready. The kubernetes backend cannot be
+auto-built: point the image template at a registry the cluster can pull.
+
+Pre-building is still possible to skip the first-start wait, or to push to a
+registry:
 
 ```sh
 docker build --build-arg AOE_VERSION=v0.5.0 -t cityhall/aoe:v0.5.0 deploy/aoe-image/
@@ -35,8 +44,8 @@ docker build --build-arg AOE_VERSION=v0.5.0 -t cityhall/aoe:v0.5.0 deploy/aoe-im
 
 On a first startup the default version is pre-filled with the latest aoe
 release (skipped when offline); adjust it under **Settings → Workspaces** if
-needed. Starting a workspace with no default version set, or with an image
-that is not built, fails with a descriptive error.
+needed. Starting a workspace with no default version set fails with a
+descriptive error.
 
 Members hold the `workspaces.use` permission by default and can open their own
 workspace. `workspaces.read` / `workspaces.write` gate the admin Workspaces
@@ -86,15 +95,13 @@ host. WebSocket upgrade forwarding must be enabled on the external proxy.
   the helm chart; without the NetworkPolicy any pod in the cluster can reach
   the auth-none workspaces.
 - **`process`** (unix). One detached `aoe serve` per user with an isolated
-  HOME under `WORKSPACE_PROCESS_DIR`, for VPS hosts without docker. Install
-  each served version's binary at
-  `$WORKSPACE_PROCESS_DIR/versions/<version>/aoe` (from the aoe release
-  tarball). Processes survive CityHall restarts. This isolates data, not
+  HOME under `WORKSPACE_PROCESS_DIR`, for VPS hosts without docker. Version
+  binaries live at `$WORKSPACE_PROCESS_DIR/versions/<version>/aoe`,
+  downloaded automatically from the release tarball (or installed there
+  manually). Processes survive CityHall restarts. This isolates data, not
   security: every workspace runs as the CityHall OS user.
 
 ## Current limitations
 
-- Workspace images are operator-built ([#17](https://github.com/agent-of-empires/cityhall/issues/17)
-  tracks auto-pull/build).
 - Agent credentials are not forwarded into workspaces yet
   ([#16](https://github.com/agent-of-empires/cityhall/issues/16)).

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -54,6 +54,16 @@ Members hold the `workspaces.use` permission by default and can open their own
 workspace. `workspaces.read` / `workspaces.write` gate the admin Workspaces
 page and its actions.
 
+`workspaces.impersonate` (never implied by `workspaces.read`) lets an admin
+open another user's workspace for support: the Open action mints a short-lived
+access link, and exchanging it scopes that browser's workspace origin to the
+target user for up to 30 minutes (every workspace tab, not just the new one).
+Each grant and exit is written to the server log as an audit line. The
+top-bar "Open workspace" link always exits admin access first; note that
+WebSocket connections opened during access survive until they disconnect,
+even past expiry or permission revocation. Requires `CITYHALL_SECRET_KEY`.
+The target's idle accounting keeps running while an admin browses.
+
 ## The workspace proxy
 
 Workspaces are served through a dedicated listener (default

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -60,7 +60,9 @@ export function TopBar({ me, onLogout }: { me: Me; onLogout: () => Promise<void>
       <div className="flex items-center gap-3">
         {workspaceOrigin && (
           <a
-            href={workspaceOrigin}
+            // The exit param ends any admin access to another user's
+            // workspace first, so this link always opens YOUR workspace.
+            href={`${workspaceOrigin}/?cityhall_ws_exit=1`}
             target="_blank"
             rel="noreferrer"
             className="flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-text-secondary transition-colors hover:text-text-primary"

--- a/web/src/components/WorkspaceSettings.tsx
+++ b/web/src/components/WorkspaceSettings.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { api, ApiError, type WorkspaceSettings } from "../lib/api";
-import { Button, ErrorText, Field, Input } from "./ui";
+import { isOlderVersion } from "../lib/versions";
+import { Button, ErrorText, Field, Input, Select } from "./ui";
 
 export function WorkspaceSettingsSection() {
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -8,6 +9,8 @@ export function WorkspaceSettingsSection() {
   const [imageTemplate, setImageTemplate] = useState("");
   const [defaultVersion, setDefaultVersion] = useState("");
   const [idleStopMinutes, setIdleStopMinutes] = useState(30);
+  const [versions, setVersions] = useState<string[]>([]);
+  const [latest, setLatest] = useState<string | null>(null);
 
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -30,6 +33,13 @@ export function WorkspaceSettingsSection() {
 
   useEffect(() => {
     void load();
+    api
+      .listWorkspaceVersions()
+      .then((v) => {
+        setVersions(v.versions);
+        setLatest(v.latest);
+      })
+      .catch(() => {});
   }, [load]);
 
   async function save(e: React.FormEvent) {
@@ -69,7 +79,23 @@ export function WorkspaceSettingsSection() {
             />
           </Field>
           <Field label="Default version">
-            <Input value={defaultVersion} onChange={(e) => setDefaultVersion(e.target.value)} placeholder="v0.1.0" />
+            {versions.length > 0 ? (
+              <Select value={defaultVersion} onChange={(e) => setDefaultVersion(e.target.value)}>
+                <option value="">none</option>
+                {/* A previously saved version can predate the discovered list. */}
+                {defaultVersion && !versions.includes(defaultVersion) && (
+                  <option value={defaultVersion}>{defaultVersion}</option>
+                )}
+                {versions.map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                    {v === latest ? " (latest)" : ""}
+                  </option>
+                ))}
+              </Select>
+            ) : (
+              <Input value={defaultVersion} onChange={(e) => setDefaultVersion(e.target.value)} placeholder="v0.1.0" />
+            )}
           </Field>
           <Field label="Idle stop (minutes)">
             <Input
@@ -85,6 +111,15 @@ export function WorkspaceSettingsSection() {
           The image for a user is the template with <code className="text-text-primary">{"{version}"}</code> replaced by
           their pinned version (or the default). Idle workspaces are stopped automatically; their data volume is kept.
         </p>
+
+        {latest && defaultVersion && isOlderVersion(defaultVersion, latest) && (
+          <p className="text-sm text-status-waiting">
+            The default version {defaultVersion} is behind the latest release {latest}.{" "}
+            <button type="button" className="underline" onClick={() => setDefaultVersion(latest)}>
+              Use {latest}
+            </button>
+          </p>
+        )}
 
         {saveError && <ErrorText>{saveError}</ErrorText>}
         {saved && <p className="text-sm text-status-running">Settings saved.</p>}

--- a/web/src/components/WorkspacesPage.tsx
+++ b/web/src/components/WorkspacesPage.tsx
@@ -65,6 +65,23 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
     return () => clearInterval(timer);
   }, [anyProvisioning, load]);
 
+  // Statuses change outside this tab (the proxy auto-starts workspaces on
+  // access), so refresh when the tab regains focus and poll slowly while
+  // visible.
+  useEffect(() => {
+    const refresh = () => {
+      if (!document.hidden) void load();
+    };
+    document.addEventListener("visibilitychange", refresh);
+    window.addEventListener("focus", refresh);
+    const timer = setInterval(refresh, 10_000);
+    return () => {
+      document.removeEventListener("visibilitychange", refresh);
+      window.removeEventListener("focus", refresh);
+      clearInterval(timer);
+    };
+  }, [load]);
+
   function toggle(userId: number) {
     setSelected((prev) => {
       const next = new Set(prev);

--- a/web/src/components/WorkspacesPage.tsx
+++ b/web/src/components/WorkspacesPage.tsx
@@ -44,6 +44,15 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
       .catch(() => {});
   }, [load]);
 
+  // While an image pull/build or binary download runs, poll so progress and
+  // completion show up without a manual refresh.
+  const anyProvisioning = items.some((i) => i.provisioning && !i.provisioning.failed);
+  useEffect(() => {
+    if (!anyProvisioning) return;
+    const timer = setInterval(() => void load(), 3000);
+    return () => clearInterval(timer);
+  }, [anyProvisioning, load]);
+
   function toggle(userId: number) {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -140,7 +149,21 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
                     </td>
                   )}
                   <td className="px-4 py-2.5 text-text-primary">{item.username}</td>
-                  <td className={`px-4 py-2.5 ${STATUS_STYLES[item.status]}`}>{STATUS_LABELS[item.status]}</td>
+                  <td className="px-4 py-2.5">
+                    {item.provisioning ? (
+                      <span
+                        className={item.provisioning.failed ? "text-status-error" : "text-status-waiting"}
+                        title={item.provisioning.message}
+                      >
+                        {item.provisioning.failed ? "provisioning failed" : "provisioning"}
+                        <span className="block max-w-56 truncate text-xs text-text-muted">
+                          {item.provisioning.message}
+                        </span>
+                      </span>
+                    ) : (
+                      <span className={STATUS_STYLES[item.status]}>{STATUS_LABELS[item.status]}</span>
+                    )}
+                  </td>
                   <td className="px-4 py-2.5 text-text-secondary">
                     {item.pinned_version ?? (item.effective_version ? `default (${item.effective_version})` : "-")}
                   </td>

--- a/web/src/components/WorkspacesPage.tsx
+++ b/web/src/components/WorkspacesPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Play, Square, Trash2 } from "lucide-react";
+import { ExternalLink, Play, Square, Trash2 } from "lucide-react";
 import { api, ApiError, can, type Me, type WorkspaceItem } from "../lib/api";
 import { isOlderVersion } from "../lib/versions";
 import { TopBar } from "./TopBar";
@@ -21,6 +21,7 @@ const STATUS_LABELS: Record<WorkspaceItem["status"], string> = {
 
 export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promise<void> }) {
   const canWrite = can(me, "workspaces.write");
+  const canImpersonate = can(me, "workspaces.impersonate");
   const [items, setItems] = useState<WorkspaceItem[]>([]);
   const [proxyOrigin, setProxyOrigin] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -99,6 +100,22 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
 
   function selectOutdated() {
     setSelected(new Set(items.filter(outdated).map((i) => i.user_id)));
+  }
+
+  async function openAsAdmin(item: WorkspaceItem) {
+    if (
+      !confirm(
+        `Open ${item.username}'s workspace? Every workspace tab in this browser will show ` +
+          `their workspace until you exit (via "Open workspace" in the top bar) or 30 minutes pass. ` +
+          `This access is audited.`,
+      )
+    ) {
+      return;
+    }
+    await run(async () => {
+      const { url } = await api.workspaceAccessUrl(item.user_id);
+      window.open(url, "_blank", "noopener");
+    }, "could not open workspace");
   }
 
   async function destroy(item: WorkspaceItem) {
@@ -252,6 +269,16 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
                   {canWrite && (
                     <td className="px-4 py-2.5">
                       <div className="flex justify-end gap-1">
+                        {canImpersonate && item.user_id !== me.id && (
+                          <Button
+                            variant="ghost"
+                            disabled={busy}
+                            onClick={() => openAsAdmin(item)}
+                            title="Open this user's workspace (audited)"
+                          >
+                            <ExternalLink size={14} />
+                          </Button>
+                        )}
                         <Button
                           variant="ghost"
                           disabled={busy || item.status === "running"}

--- a/web/src/components/WorkspacesPage.tsx
+++ b/web/src/components/WorkspacesPage.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { Play, Square, Trash2 } from "lucide-react";
 import { api, ApiError, can, type Me, type WorkspaceItem } from "../lib/api";
+import { isOlderVersion } from "../lib/versions";
 import { TopBar } from "./TopBar";
-import { Button, Input } from "./ui";
+import { Button, Input, Select } from "./ui";
 
 const STATUS_STYLES: Record<WorkspaceItem["status"], string> = {
   running: "text-status-running",
@@ -25,7 +26,10 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [version, setVersion] = useState("");
+  const [restart, setRestart] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [versions, setVersions] = useState<string[]>([]);
+  const [latest, setLatest] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -41,6 +45,13 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
     api
       .myWorkspace()
       .then((w) => setProxyOrigin(w.proxy_origin))
+      .catch(() => {});
+    api
+      .listWorkspaceVersions()
+      .then((v) => {
+        setVersions(v.versions);
+        setLatest(v.latest);
+      })
       .catch(() => {});
   }, [load]);
 
@@ -77,9 +88,17 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
 
   async function applyVersion() {
     const ids = [...selected];
-    await run(() => api.bulkSetWorkspaceVersion(ids, version.trim() || null), "could not set version");
+    await run(() => api.bulkSetWorkspaceVersion(ids, version.trim() || null, restart), "could not set version");
     setSelected(new Set());
     setVersion("");
+  }
+
+  function outdated(item: WorkspaceItem): boolean {
+    return latest !== null && item.effective_version !== null && isOlderVersion(item.effective_version, latest);
+  }
+
+  function selectOutdated() {
+    setSelected(new Set(items.filter(outdated).map((i) => i.user_id)));
   }
 
   async function destroy(item: WorkspaceItem) {
@@ -97,12 +116,38 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
           <h2 className="font-mono text-xs uppercase tracking-wider text-text-muted">Workspaces</h2>
           {canWrite && (
             <div className="flex items-end gap-2">
-              <Input
-                value={version}
-                onChange={(e) => setVersion(e.target.value)}
-                placeholder="version, empty = default"
-                className="w-52"
-              />
+              {items.some(outdated) && (
+                <Button variant="ghost" disabled={busy} onClick={selectOutdated}>
+                  Select outdated
+                </Button>
+              )}
+              <label className="flex items-center gap-1.5 text-xs text-text-secondary">
+                <input
+                  type="checkbox"
+                  checked={restart}
+                  onChange={(e) => setRestart(e.target.checked)}
+                  className="h-4 w-4 accent-brand-500"
+                />
+                restart running now
+              </label>
+              {versions.length > 0 ? (
+                <Select value={version} onChange={(e) => setVersion(e.target.value)} className="w-52">
+                  <option value="">follow default</option>
+                  {versions.map((v) => (
+                    <option key={v} value={v}>
+                      {v}
+                      {v === latest ? " (latest)" : ""}
+                    </option>
+                  ))}
+                </Select>
+              ) : (
+                <Input
+                  value={version}
+                  onChange={(e) => setVersion(e.target.value)}
+                  placeholder="version, empty = default"
+                  className="w-52"
+                />
+              )}
               <Button variant="primary" disabled={busy || selected.size === 0} onClick={applyVersion}>
                 Set version ({selected.size})
               </Button>
@@ -165,7 +210,41 @@ export function WorkspacesPage({ me, onLogout }: { me: Me; onLogout: () => Promi
                     )}
                   </td>
                   <td className="px-4 py-2.5 text-text-secondary">
-                    {item.pinned_version ?? (item.effective_version ? `default (${item.effective_version})` : "-")}
+                    <div className="flex items-center gap-2">
+                      {canWrite && versions.length > 0 ? (
+                        <Select
+                          value={item.pinned_version ?? ""}
+                          disabled={busy}
+                          onChange={(e) =>
+                            run(
+                              () => api.setWorkspaceVersion(item.user_id, e.target.value || null, restart),
+                              "could not set version",
+                            )
+                          }
+                          className="w-44"
+                        >
+                          <option value="">
+                            {item.effective_version ? `default (${item.effective_version})` : "default"}
+                          </option>
+                          {versions.map((v) => (
+                            <option key={v} value={v}>
+                              {v}
+                              {v === latest ? " (latest)" : ""}
+                            </option>
+                          ))}
+                        </Select>
+                      ) : (
+                        <span>
+                          {item.pinned_version ??
+                            (item.effective_version ? `default (${item.effective_version})` : "-")}
+                        </span>
+                      )}
+                      {outdated(item) && (
+                        <span className="text-xs font-medium text-status-waiting" title={`latest is ${latest}`}>
+                          outdated
+                        </span>
+                      )}
+                    </div>
                   </td>
                   <td className="px-4 py-2.5 text-text-secondary">
                     {item.last_active_at ? new Date(item.last_active_at).toLocaleString() : "-"}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -114,6 +114,7 @@ export interface WorkspaceItem {
   pinned_version: string | null;
   effective_version: string | null;
   last_active_at: string | null;
+  provisioning: { message: string; failed: boolean } | null;
 }
 
 export interface MyWorkspace {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -258,6 +258,8 @@ export const api = {
     }),
   listWorkspaceVersions: () =>
     request<{ latest: string | null; versions: string[]; stale: boolean }>("/workspaces/versions"),
+  workspaceAccessUrl: (userId: number) =>
+    request<{ url: string }>(`/workspaces/${userId}/access-url`, { method: "POST" }),
   getWorkspaceSettings: () => request<WorkspaceSettings>("/settings/workspaces"),
   updateWorkspaceSettings: (patch: WorkspaceSettings) =>
     request<WorkspaceSettings>("/settings/workspaces", {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -246,16 +246,18 @@ export const api = {
   startWorkspace: (userId: number) => request<{ status: string }>(`/workspaces/${userId}/start`, { method: "POST" }),
   stopWorkspace: (userId: number) => request<{ status: string }>(`/workspaces/${userId}/stop`, { method: "POST" }),
   destroyWorkspace: (userId: number) => request<{ destroyed: boolean }>(`/workspaces/${userId}`, { method: "DELETE" }),
-  setWorkspaceVersion: (userId: number, pinnedVersion: string | null) =>
+  setWorkspaceVersion: (userId: number, pinnedVersion: string | null, restart = false) =>
     request<{ pinned_version: string | null }>(`/workspaces/${userId}`, {
       method: "PATCH",
-      body: JSON.stringify({ pinned_version: pinnedVersion }),
+      body: JSON.stringify({ pinned_version: pinnedVersion, restart }),
     }),
-  bulkSetWorkspaceVersion: (userIds: number[], pinnedVersion: string | null) =>
+  bulkSetWorkspaceVersion: (userIds: number[], pinnedVersion: string | null, restart = false) =>
     request<{ pinned_version: string | null }>("/workspaces", {
       method: "PATCH",
-      body: JSON.stringify({ user_ids: userIds, pinned_version: pinnedVersion }),
+      body: JSON.stringify({ user_ids: userIds, pinned_version: pinnedVersion, restart }),
     }),
+  listWorkspaceVersions: () =>
+    request<{ latest: string | null; versions: string[]; stale: boolean }>("/workspaces/versions"),
   getWorkspaceSettings: () => request<WorkspaceSettings>("/settings/workspaces"),
   updateWorkspaceSettings: (patch: WorkspaceSettings) =>
     request<WorkspaceSettings>("/settings/workspaces", {

--- a/web/src/lib/versions.ts
+++ b/web/src/lib/versions.ts
@@ -1,0 +1,21 @@
+// Version ordering by numeric components ("v1.10.0" > "v1.9.9"); mirrors the
+// server's version_key. Tags without digits compare as empty and are never
+// considered outdated.
+export function versionKey(tag: string): number[] {
+  return tag
+    .split(/[^0-9]+/)
+    .filter((s) => s.length > 0)
+    .map((s) => Number(s));
+}
+
+export function isOlderVersion(tag: string, latest: string): boolean {
+  const a = versionKey(tag);
+  const b = versionKey(latest);
+  if (a.length === 0 || b.length === 0) return false;
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) return x < y;
+  }
+  return false;
+}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Four follow-ups to the workspace orchestrator (#21), landed as one stack because each builds on the previous.

**Backends and topologies (#18).** `WORKSPACE_BACKEND` selects how workspaces run, failing startup fast on invalid config. The docker backend gains a shared-network addressing mode (`WORKSPACE_DOCKER_NETWORK`): workspaces join a named docker network with no published ports and are dialed by container DNS, which is how CityHall itself runs in compose with the socket mounted. A new kubernetes backend drives one PVC + Service + scale-to-zero `Recreate` Deployment per user through `kubectl` (declarative apply, so first start, resume, and version drift are one operation), and a new bare-process backend for docker-less VPSes spawns one detached `aoe serve` per user with an isolated HOME, per-version binaries, and a state file that survives CityHall restarts. The policy layer now caches workspace endpoints per user so proxied requests stop paying a backend shell-out each; stop, destroy, the idle sweeper, and failed dials invalidate. Deploy examples wire all of it: a compose workspaces overlay, k8s and helm RBAC plus a NetworkPolicy that keeps other pods away from the auth-none workspaces, systemd env, and the CityHall image now ships static docker and kubectl binaries.

**Image provisioning (#17).** A missing artifact provisions itself in a detached background job, single-flight per artifact: docker tries `docker pull`, then builds from the reference Dockerfile (embedded at compile time and piped to `docker build` with no context); the process backend downloads the version's release tarball, streamed to disk with member-only extraction and atomic install. Requests get a fast 503 with Retry-After instead of hanging on a multi-minute build (and a closed tab can no longer kill one), failures stay sticky for a minute with the error visible, and the admin Workspaces page shows live provisioning progress.

**Version management UX (#19).** Stable aoe releases are discovered from the GitHub API into a single-flight 1h cache that serves the last known list when GitHub is down (optional `GITHUB_TOKEN` for rate limits). Every version input becomes a dropdown fed by it, rows behind the latest release show an outdated badge with a select-outdated shortcut for one-click group updates, the settings page hints when the default version is behind latest, and pins can opt into eagerly restarting currently-running workspaces via a background rollout that never touches idle accounting. The workspaces page also live-refreshes on tab focus and polls while visible, so statuses changed elsewhere (e.g. the proxy auto-starting a workspace) show up without a manual reload.

**Admin access to another user's workspace (#22).** A new `workspaces.impersonate` permission (deliberately not implied by `workspaces.read`) gates `POST /api/workspaces/{user_id}/access-url`, which mints a 120-second AES-GCM token. The proxy exchanges it for a 30-minute HttpOnly cookie on its own origin and routes that browser to the target's workspace, with activity and websocket leases keyed to the target so their idle accounting keeps working. Every grant and exit emits a structured audit log line; a stale or revoked cookie yields 403 and clears rather than silently switching the browser back to the admin's own workspace.

#20 (same-origin proxy compat mode) was investigated and deliberately dropped: aoe has no base-path support yet and serves its own API under `/api/*`, so the allowlist approach is collision-prone; findings and the upstream-first recommendation are on the issue.

Closes #18
Closes #17
Closes #19
Closes #22

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] With no `WORKSPACE_BACKEND` set, workspaces behave exactly as on main (loopback docker containers); set `WORKSPACE_BACKEND=bogus` and confirm CityHall refuses to start with a clear error.
- [ ] Compose topology: `docker compose -f deploy/docker-compose.prod.yml -f deploy/docker-compose.workspaces.yml up -d --build`, open a workspace, and confirm the container joined `cityhall-workspaces` with no published ports (`docker ps`).
- [ ] Process backend: run CityHall with `WORKSPACE_BACKEND=process WORKSPACE_PROCESS_DIR=/tmp/aoe-ws`, open your workspace, confirm the binary auto-downloads into `versions/<v>/aoe` and an `aoe serve` process appears; restart CityHall and confirm the workspace is still reachable without a respawn.
- [ ] Provisioning UX: pick a version whose image is not built, open the workspace, confirm the browser gets the retry-shortly error while the admin Workspaces page shows "pulling image ..." then "building image ...", and that the workspace serves once the build finishes.
- [ ] Provisioning failure: pin a nonexistent version (free-text), start it, and confirm the admin page shows the failure message and the build is not re-attempted on every refresh.
- [ ] Version dropdowns: confirm the settings default version, the bulk pin bar, and each row offer discovered releases with the latest marked, and that an old effective version shows the outdated badge plus the select-outdated shortcut.
- [ ] Eager restart: pin a running workspace to another version with "restart running now" checked and confirm it recreates immediately (volume kept); repeat on a stopped workspace and confirm it stays stopped.
- [ ] Admin access: as an admin, use the Open action on another user's row, confirm you land in their workspace, the server log shows the audit line, and the target's row keeps updating "last active"; use the top bar "Open workspace" link and confirm you are back in your own.
- [ ] Access control: remove `workspaces.impersonate` from a role (or use a non-admin with `workspaces.read`), confirm the Open action is gone and the endpoint returns 403; with an active access cookie, revoke the permission and confirm the proxy returns 403 instead of showing your own workspace.

## Checklist

- [x] New and existing tests pass
- [x] `cargo fmt` / `cargo clippy` clean (API changes)
- [x] `npm run lint` / `npm run format:check` clean (web changes)
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, `/aoe-implement` skill). Investigation, plans, and implementation drafted by Claude under my direction; each plan was consulted against external models, and I reviewed and approved every step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker, Kubernetes, and bare-process workspace backends.
  * Workspaces now show provisioning progress, failures, and actionable retry information.
  * Added workspace version discovery, outdated-version selection, and optional immediate restarts.
  * Added admin workspace access links with permission checks and session protection.
  * Added Kubernetes deployment support, including storage, RBAC, and network isolation.
  * Added Docker Compose and Helm configuration options for workspaces.

* **Bug Fixes**
  * Improved workspace readiness detection and recovery from stale endpoints or failed starts.

* **Documentation**
  * Expanded workspace setup, backend, configuration, and deployment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
