### PR TITLE
feat: run workspaces in aoe's CityHall client mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Thumbs.db
 # Local config
 .env
 .env.local
+docker-compose.override.yml
 
 # SQLite databases (default DATABASE_URL creates cityhall.db in the cwd)
 *.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,19 @@ COPY web/ ./
 RUN npm run build
 
 # --- Backend build --------------------------------------------------------
-FROM rust:1-slim AS api
+# Pinned to bookworm to match the runtime stage's glibc: the floating
+# `rust:1-slim` tag moved to trixie (glibc 2.39), which the bookworm runtime
+# (2.36) cannot load.
+FROM rust:1-slim-bookworm AS api
 WORKDIR /app
 # Deliberately do NOT copy rust-toolchain.toml: it pins channel = "stable",
 # which makes rustup re-resolve and re-download the stable toolchain on every
 # build. The base image already ships a stable toolchain, which is fine here.
 COPY Cargo.toml Cargo.lock ./
 COPY api/ api/
+# The docker workspace backend embeds this at compile time (include_str!) to
+# build workspace images when the registry has none.
+COPY deploy/aoe-image/Dockerfile deploy/aoe-image/Dockerfile
 # The frontend is built in its own stage and copied into the runtime image,
 # so skip build.rs's npm invocation here.
 ENV SKIP_FRONTEND_BUILD=1

--- a/api/src/orchestrator/docker.rs
+++ b/api/src/orchestrator/docker.rs
@@ -20,8 +20,8 @@ use serde::Deserialize;
 use tokio::process::Command;
 
 use super::{
-    wait_ready, Begin, Orchestrator, OrchestratorError, ProvisioningRegistry, WorkspaceSpec,
-    WorkspaceStatus,
+    proxy_allowed_host, proxy_allowed_origin, wait_ready, Begin, Orchestrator, OrchestratorError,
+    ProvisioningRegistry, WorkspaceSpec, WorkspaceStatus,
 };
 
 /// Port aoe serves on inside the workspace container.
@@ -360,6 +360,14 @@ fn run_args(spec: &WorkspaceSpec, network: Option<&str>) -> Vec<String> {
             "--auth",
             "none",
             "--behind-proxy",
+            // The proxy forwards the public Host and Origin, both of which
+            // aoe's DNS-rebinding gate requires on the allowlist.
+            "--allowed-host",
+            &proxy_allowed_host(),
+            "--allowed-origin",
+            &proxy_allowed_origin(),
+            // Locked-down end-user client: composer + structured view only.
+            "--cityhall",
         ]
         .iter()
         .map(|s| s.to_string()),
@@ -511,6 +519,15 @@ mod tests {
         assert!(!args
             .iter()
             .any(|a| a.starts_with("cityhall.workspace.network=")));
+    }
+
+    #[test]
+    fn workspaces_run_in_cityhall_client_mode() {
+        let args = run_args(&spec(), None);
+        // Locked-down end-user client, never the full aoe dashboard.
+        assert!(args.iter().any(|a| a == "--cityhall"));
+        // --behind-proxy without this makes `aoe serve` refuse to start.
+        assert!(args.iter().any(|a| a == "--allowed-host"));
     }
 
     #[test]

--- a/api/src/orchestrator/kubernetes.rs
+++ b/api/src/orchestrator/kubernetes.rs
@@ -16,7 +16,10 @@ use serde_json::json;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
-use super::{http_probe, Orchestrator, OrchestratorError, WorkspaceSpec, WorkspaceStatus};
+use super::{
+    http_probe, proxy_allowed_host, proxy_allowed_origin, Orchestrator, OrchestratorError,
+    WorkspaceSpec, WorkspaceStatus,
+};
 
 /// Port aoe serves on inside the workspace pod.
 const AOE_PORT: u16 = 8080;
@@ -312,6 +315,14 @@ fn render_manifests(
                                     // shipped NetworkPolicy keeps other pods out.
                                     "--auth", "none",
                                     "--behind-proxy",
+                                    // The proxy forwards the public Host and
+                                    // Origin, both of which aoe's DNS-rebinding
+                                    // gate requires on the allowlist.
+                                    "--allowed-host", proxy_allowed_host(),
+                                    "--allowed-origin", proxy_allowed_origin(),
+                                    // Locked-down end-user client: composer +
+                                    // structured view only.
+                                    "--cityhall",
                                 ],
                                 "ports": [{ "containerPort": AOE_PORT }],
                                 "volumeMounts": [{ "name": "data", "mountPath": AOE_DATA_DIR }],
@@ -418,6 +429,11 @@ mod tests {
             container["volumeMounts"][0]["mountPath"],
             "/home/aoe/.config/agent-of-empires"
         );
+        // Workspaces are locked-down end-user clients, never full dashboards.
+        let args = container["args"].as_array().unwrap();
+        assert!(args.iter().any(|a| a == "--cityhall"));
+        // --behind-proxy without this makes `aoe serve` refuse to start.
+        assert!(args.iter().any(|a| a == "--allowed-host"));
     }
 
     #[test]

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -199,6 +199,43 @@ pub fn render_image(template: &str, version: &str) -> String {
     template.replace("{version}", version)
 }
 
+/// The `Host` value browsers reach workspaces on, for aoe's DNS-rebinding
+/// gate: `aoe serve --behind-proxy` refuses to start without at least one
+/// `--allowed-host`, and the proxy forwards the public host it was called on.
+/// A port in the value is harmless (aoe strips it before matching).
+pub fn proxy_allowed_host() -> String {
+    allowed_host_from_origin(&proxy_allowed_origin())
+}
+
+/// Default public origin: the proxy's own default bind, reached on loopback.
+const DEFAULT_PROXY_ORIGIN: &str = "http://localhost:3001";
+
+/// The browser `Origin` the proxy forwards to workspaces. aoe derives allowed
+/// origins from `--allowed-host` only for the standard ports, so a proxy on
+/// `:3001` (or any nonstandard port) has to be spelled out or every fetch and
+/// WebSocket from the dashboard is refused.
+pub fn proxy_allowed_origin() -> String {
+    let origin = std::env::var("WORKSPACE_PROXY_PUBLIC_ORIGIN").unwrap_or_default();
+    let origin = origin.trim().trim_end_matches('/');
+    if origin.is_empty() {
+        DEFAULT_PROXY_ORIGIN.to_string()
+    } else {
+        origin.to_string()
+    }
+}
+
+/// The host part of a proxy origin.
+fn allowed_host_from_origin(origin: &str) -> String {
+    origin
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(origin)
+        .split('/')
+        .next()
+        .unwrap_or_default()
+        .to_string()
+}
+
 /// How long to wait for aoe to accept connections after a start.
 const READY_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -247,6 +284,19 @@ pub(crate) async fn http_probe(addr: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn allowed_host_comes_from_the_proxy_origin() {
+        assert_eq!(
+            allowed_host_from_origin("https://ws.example.com"),
+            "ws.example.com"
+        );
+        // A port is kept: aoe strips it before matching the Host header.
+        assert_eq!(
+            allowed_host_from_origin("http://localhost:3001"),
+            "localhost:3001"
+        );
+    }
 
     #[test]
     fn render_image_substitutes_version() {

--- a/api/src/orchestrator/process.rs
+++ b/api/src/orchestrator/process.rs
@@ -20,8 +20,8 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    binary_key, http_probe, wait_ready, Begin, Orchestrator, OrchestratorError,
-    ProvisioningRegistry, WorkspaceSpec, WorkspaceStatus,
+    binary_key, http_probe, proxy_allowed_host, proxy_allowed_origin, wait_ready, Begin,
+    Orchestrator, OrchestratorError, ProvisioningRegistry, WorkspaceSpec, WorkspaceStatus,
 };
 
 /// Grace period between SIGTERM and SIGKILL on stop.
@@ -157,6 +157,14 @@ impl ProcessOrchestrator {
             "--auth",
             "none",
             "--behind-proxy",
+            // The proxy forwards the public Host and Origin, both of which
+            // aoe's DNS-rebinding gate requires on the allowlist.
+            "--allowed-host",
+            &proxy_allowed_host(),
+            "--allowed-origin",
+            &proxy_allowed_origin(),
+            // Locked-down end-user client: composer + structured view only.
+            "--cityhall",
         ])
         .env("HOME", home)
         .current_dir(home)

--- a/api/src/proxy.rs
+++ b/api/src/proxy.rs
@@ -10,7 +10,8 @@
 //!
 //! Every request is gated on the CityHall session (`workspaces.use`), request-
 //! starts the caller's workspace, and is forwarded to it. The workspace itself
-//! runs `aoe serve --auth=none --behind-proxy` and is only reachable through
+//! runs `aoe serve --auth=none --behind-proxy --allowed-host <proxy-host> --cityhall`
+//! and is only reachable through
 //! loopback, so CityHall is the sole auth boundary.
 
 use std::net::SocketAddr;
@@ -326,6 +327,10 @@ fn forward_headers(parts: &request::Parts) -> HeaderMap {
     }
     if let Some(host) = parts.headers.get(HOST) {
         headers.insert("x-forwarded-host", host.clone());
+        // aoe's DNS-rebinding gate reads the real Host, not X-Forwarded-Host,
+        // so pass the public one through: without it the workspace sees the
+        // internal container/service authority and 403s every request.
+        headers.insert(HOST, host.clone());
     }
     headers.insert("x-forwarded-proto", HeaderValue::from_static("http"));
     if let Some(ConnectInfo(peer)) = parts.extensions.get::<ConnectInfo<SocketAddr>>() {

--- a/deploy/aoe-image/Dockerfile
+++ b/deploy/aoe-image/Dockerfile
@@ -6,7 +6,8 @@
 # The tag must match the workspace settings image template (default
 # `cityhall/aoe:{version}`) rendered with the version users are pinned to.
 # CityHall starts containers from this image with:
-#   aoe serve --host 0.0.0.0 --port 8080 --auth none --behind-proxy
+#   aoe serve --host 0.0.0.0 --port 8080 --auth none --behind-proxy \
+#     --allowed-host <proxy-host> --cityhall
 # and mounts a per-user volume at /home/aoe/.config/agent-of-empires.
 
 FROM debian:bookworm-slim

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -6,6 +6,13 @@ default; kubernetes and bare-process backends are available, see
 [Backends](#backends)). Each workspace has a persistent data volume, so aoe
 sessions and configuration survive stops, restarts, and version changes.
 
+Every workspace runs with `--cityhall`, aoe's locked-down client mode: users
+get the message composer and the structured (chat) view only, with terminal
+and diff panes, project management, and advanced settings hidden in the UI and
+refused server-side. The flag requires an aoe version that supports it;
+starting a workspace on an older version fails with an unknown-argument error
+from `aoe serve`.
+
 ## How it works
 
 - **Request-driven start.** Opening the workspace (the "Open workspace" link,
@@ -70,10 +77,17 @@ Workspaces are served through a dedicated listener (default
 `127.0.0.1:3001`), separate from the main CityHall origin, because the aoe
 dashboard owns root-absolute paths. Every proxied request is authenticated
 with the regular CityHall session cookie; the container itself runs
-`aoe serve --auth=none --behind-proxy` and is only reachable through a
+`aoe serve --auth=none --behind-proxy --allowed-host <proxy-host> --cityhall`
+and is only reachable through a
 loopback-published port, so CityHall is the sole auth boundary. In development
 nothing needs configuring: the cookie set by `127.0.0.1:3000` is also sent to
 `127.0.0.1:3001` (cookies ignore ports).
+
+The allowed host is the host part of `WORKSPACE_PROXY_PUBLIC_ORIGIN` (defaulting
+to `localhost`), because the proxy forwards the public `Host` it was called on
+and aoe's DNS-rebinding gate refuses `--behind-proxy` without an allowlist
+entry. Set that variable to the origin browsers actually use, or workspaces
+answer 403 to every proxied request.
 
 For production, expose the proxy listener through your reverse proxy as either
 a subdomain or a second external port, and set `WORKSPACE_PROXY_PUBLIC_ORIGIN`


### PR DESCRIPTION
> Written with Claude Code (Claude Opus 5). Reviewed by a human before opening.

Now that agent-of-empires#2853 has landed, CityHall can hand `aoe serve` the flag that locks the dashboard down for non-technical end users. Every workspace backend (docker, kubernetes, process) now spawns with `--cityhall`, so a workspace is a composer plus structured-view client only: terminal and diff panes, project management, and advanced settings are hidden in the UI and refused server-side.

Getting that far surfaced three pre-existing breakages, fixed in their own commits:

1. **The image build was broken.** The api stage copied only `api/`, but `orchestrator/docker.rs` embeds `deploy/aoe-image/Dockerfile` via `include_str!`, so `docker compose build` failed to compile.
2. **glibc mismatch.** The floating `rust:1-slim` tag moved to Debian trixie (glibc 2.39) while the runtime stage is bookworm (2.36), so the build script and the binary both failed to load. Builder pinned to bookworm.
3. **Workspaces could not answer any request.** aoe has required `--allowed-host` alongside `--behind-proxy` since v1.13.0 (agent-of-empires `e9a0f23b`), and its DNS-rebinding gate reads the real `Host`, not `X-Forwarded-Host`. The proxy stripped `Host`, so the workspace saw the internal container authority and returned `forbidden: host or origin not allowed`. The proxy now forwards the public `Host`, and the spawn args carry `--allowed-host` plus `--allowed-origin` derived from `WORKSPACE_PROXY_PUBLIC_ORIGIN` (the origin is needed explicitly because aoe derives origins from the allowed host only for ports 80 and 443).

Note that `--cityhall` requires an aoe version that supports it. No release has it yet, so older versions fail loudly at spawn with an unknown-argument error rather than silently serving an unlocked dashboard. Verified against a locally built aoe binary baked into `cityhall/aoe:v1.13.2`.

Closes #7 on the CityHall side.

## Testing

Requires an aoe build that has `--cityhall` (build from agent-of-empires main and tag it as the image the workspace settings resolve to).

- [ ] `cd api && cargo test --bin cityhall` passes
- [ ] `docker compose up --build` brings up cityhall, db, and mailpit, and the log shows both `cityhall listening` and `workspace proxy listening`
- [ ] Log in at http://localhost:3000, then open the workspace proxy; it serves the dashboard instead of `forbidden: host or origin not allowed`
- [ ] The dashboard shows only the composer and structured view: no terminal pane, no diff pane, no project management in the sidebar, and settings reduced to Theme, delete-to-trash, MCP, Telemetry, and Plugins
- [ ] `docker inspect cityhall-workspace-u<id> --format '{{json .Config.Cmd}}'` includes `--cityhall`, `--allowed-host`, and `--allowed-origin`
- [ ] `GET /api/about` through the proxy reports `"cityhall_mode": true`
- [ ] Creating a session by name fails with the expected no-project error (tracked separately, along with the ACP-capable default agent requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspaces now launch in restricted client mode for a more controlled experience.
  - Workspace proxy settings automatically configure allowed hosts and origins, including custom ports.
  - Forwarded workspace requests now preserve the original host information.

- **Bug Fixes**
  - Improved proxy validation helps prevent requests from unapproved hosts and returns an appropriate error when settings do not match.

- **Documentation**
  - Updated workspace setup guidance with the required proxy configuration and compatible runtime version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->