### PR TITLE
feat(web): edit the workspace config bundle as a form or as TOML

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -101,12 +101,22 @@ means nothing inside a container, so aoe clones each remote into the workspace's
 data volume and registers it. Settings are a sparse patch, so only the fields
 the admin actually changed are carried.
 
-An aoe install is a convenience here, not a prerequisite. The document is plain
-TOML and CityHall shape-checks whatever you save, so **Start from scratch** on
-that page seeds a valid skeleton to fill in by hand. Take that route when you are
-standing CityHall up before anyone has an install to export from, or when all you
-want is a project list. `schema_version = 1` on its own is a valid document; it
-just provisions nothing.
+An aoe install is a convenience here, not a prerequisite. The page offers two
+views of the same document, and switching between them carries unsaved edits:
+
+- **Form** edits the project list and a curated set of settings with labels and
+  descriptions, so no TOML has to be written. It is deliberately not every aoe
+  setting: CityHall has no aoe process to ask for the schema, and the aoe version
+  a workspace runs is per-user, so any field list it claimed to be complete could
+  describe a version nobody runs. Editing here rewrites the document from its
+  values, which drops comments; the page warns when there are any.
+- **TOML** is the whole document. It is how an uploaded export gets in, how a
+  field the form does not render gets set, and where comments survive. **Start
+  from scratch** seeds a commented skeleton to fill in by hand.
+
+Either way, `schema_version = 1` on its own is a valid document; it just
+provisions nothing. Nothing the form does not render is dropped on save: unknown
+sections, `[meta]`, and extra keys on a project are all preserved.
 
 To deliver it, set `WORKSPACE_BUNDLE_ORIGIN` to the origin a *workspace* uses to
 reach CityHall. That is not the public origin: on the docker backend it is the

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router-dom": "^7.18.1",
+        "smol-toml": "^1.7.1",
         "tailwindcss": "^4.3.2"
       },
       "devDependencies": {
@@ -2887,6 +2888,18 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.18.1",
+    "smol-toml": "^1.7.1",
     "tailwindcss": "^4.3.2"
   },
   "devDependencies": {

--- a/web/src/components/WorkspaceConfig.tsx
+++ b/web/src/components/WorkspaceConfig.tsx
@@ -1,6 +1,18 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { api, ApiError, type WorkspaceConfig } from "../lib/api";
-import { Button, ErrorText } from "./ui";
+import {
+  FIELDS,
+  parseBundle,
+  readProjects,
+  readSetting,
+  stringifyBundle,
+  writeProjects,
+  writeSetting,
+  type Doc,
+  type FormField,
+  type ProjectRow,
+} from "../lib/bundleForm";
+import { Button, ErrorText, Input, Select } from "./ui";
 
 /// Seed for an admin who has no aoe install to export from.
 ///
@@ -26,14 +38,17 @@ const BLANK_BUNDLE = `schema_version = 1
 
 /// The aoe config bundle every workspace is provisioned with (#9).
 ///
-/// A text editor rather than a form: aoe defines the settings schema, so aoe
-/// owns the format, and rendering real widgets would mean reimplementing aoe's
-/// generic field renderer here. The document is already human-editable, and the
-/// server shape-checks it on save.
+/// Two views over one document (#45). The TOML text is canonical and the form
+/// is a structured view of it, so switching either way carries unsaved edits
+/// and neither view can drift from the other. The form covers the settings that
+/// matter without an aoe install in front of you; the text view stays because
+/// it is how an export gets in and how a field CityHall does not know about gets
+/// set. See `lib/bundleForm.ts`.
 export function WorkspaceConfigSection() {
   const [config, setConfig] = useState<WorkspaceConfig | null>(null);
   const [bundle, setBundle] = useState("");
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [view, setView] = useState<"form" | "toml">("form");
 
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -81,7 +96,7 @@ export function WorkspaceConfigSection() {
     setSaved(false);
     setSaveError(null);
     try {
-      setBundle(await file.text());
+      edit(await file.text());
     } catch {
       // The picker hands back a handle, not bytes, so a file that moved or
       // became unreadable between selection and read rejects here. The caller
@@ -89,6 +104,22 @@ export function WorkspaceConfigSection() {
       // alternative to reporting it.
       setSaveError("could not read the selected file");
     }
+  }
+
+  function edit(next: string) {
+    setBundle(next);
+    setSaved(false);
+  }
+
+  const parsed = useMemo(() => parseBundle(bundle), [bundle]);
+  const doc = "doc" in parsed ? parsed.doc : null;
+  const parseError = "error" in parsed ? parsed.error : null;
+  // Only warned about when there is something to lose: the form re-emits the
+  // document from its values, so a comment does not survive an edit here.
+  const hasComments = doc !== null && /^\s*#/m.test(bundle);
+
+  function editDoc(next: Doc) {
+    edit(stringifyBundle(next));
   }
 
   const summary = config?.summary;
@@ -103,11 +134,25 @@ export function WorkspaceConfigSection() {
         <p className="text-sm text-text-secondary">
           The aoe settings and projects every workspace is provisioned with. Generate one from a configured aoe install
           with <code className="text-text-primary">aoe cityhall export</code>, or from its dashboard under Settings
-          &rarr; CityHall, then paste it here. You do not need an aoe install to start: write one here instead. Projects
-          are cloned into each workspace on its next start, so a user has something to launch a session against.
+          &rarr; CityHall, then paste it here. You do not need an aoe install to start: fill in the form instead.
+          Projects are cloned into each workspace on its next start, so a user has something to launch a session
+          against.
         </p>
 
         <div className="flex flex-wrap items-center gap-3">
+          <div className="flex gap-1 rounded-md border border-surface-700 p-1">
+            {(["form", "toml"] as const).map((v) => (
+              <Button
+                key={v}
+                type="button"
+                variant={view === v ? "primary" : "ghost"}
+                aria-pressed={view === v}
+                onClick={() => setView(v)}
+              >
+                {v === "form" ? "Form" : "TOML"}
+              </Button>
+            ))}
+          </div>
           {/* sr-only, not hidden: display:none takes the input out of the tab
               order, and the label is not focusable, so the control would be
               pointer-only. */}
@@ -126,18 +171,15 @@ export function WorkspaceConfigSection() {
               }}
             />
           </label>
-          {/* Only offered while there is nothing to lose: seeding over a real
-              document would discard an admin's work to a stray click. */}
-          {!bundle.trim() && (
+          {/* Only offered while there is nothing to lose, and only in the text
+              view: the template is entirely comments, which is exactly what the
+              form does not keep. */}
+          {view === "toml" && !bundle.trim() && (
             <button
               type="button"
               disabled={busy}
               className="cursor-pointer rounded-sm text-sm text-text-secondary underline hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
-              onClick={() => {
-                setBundle(BLANK_BUNDLE);
-                setSaved(false);
-                setSaveError(null);
-              }}
+              onClick={() => edit(BLANK_BUNDLE)}
             >
               Start from scratch
             </button>
@@ -147,21 +189,31 @@ export function WorkspaceConfigSection() {
           )}
         </div>
 
-        <textarea
-          aria-label="Workspace config bundle"
-          disabled={busy}
-          value={bundle}
-          onChange={(e) => {
-            setBundle(e.target.value);
-            setSaved(false);
-          }}
-          spellCheck={false}
-          rows={16}
-          placeholder={
-            'schema_version = 1\n\n[[projects]]\nname = "my-repo"\nremote = "https://github.com/org/my-repo.git"'
-          }
-          className="w-full rounded-md border border-surface-700 bg-surface-950 px-3 py-2 font-mono text-xs text-text-primary placeholder:text-text-muted focus:border-brand-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50"
-        />
+        {view === "form" ? (
+          doc === null ? (
+            <div className="space-y-2 rounded-md border border-surface-700 bg-surface-950 p-4">
+              <ErrorText>This document is not valid TOML: {parseError}</ErrorText>
+              <p className="text-sm text-text-secondary">
+                The form cannot show a document it cannot read. Fix it in the TOML view.
+              </p>
+            </div>
+          ) : (
+            <BundleForm doc={doc} disabled={busy} hasComments={hasComments} onChange={editDoc} />
+          )
+        ) : (
+          <textarea
+            aria-label="Workspace config bundle"
+            disabled={busy}
+            value={bundle}
+            onChange={(e) => edit(e.target.value)}
+            spellCheck={false}
+            rows={16}
+            placeholder={
+              'schema_version = 1\n\n[[projects]]\nname = "my-repo"\nremote = "https://github.com/org/my-repo.git"'
+            }
+            className="w-full rounded-md border border-surface-700 bg-surface-950 px-3 py-2 font-mono text-xs text-text-primary placeholder:text-text-muted focus:border-brand-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-50"
+          />
+        )}
 
         {summary && (summary.settings_count > 0 || summary.projects.length > 0) && (
           <p className="text-sm text-text-secondary">
@@ -186,5 +238,197 @@ export function WorkspaceConfigSection() {
         </div>
       </form>
     </>
+  );
+}
+
+function BundleForm({
+  doc,
+  disabled,
+  hasComments,
+  onChange,
+}: {
+  doc: Doc;
+  disabled: boolean;
+  hasComments: boolean;
+  onChange: (next: Doc) => void;
+}) {
+  const projects = readProjects(doc);
+
+  function setProjects(rows: ProjectRow[]) {
+    onChange(writeProjects(doc, rows));
+  }
+
+  function setProject(index: number, patch: Partial<ProjectRow>) {
+    setProjects(projects.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+  }
+
+  return (
+    <div className="space-y-6">
+      {hasComments && (
+        <p className="text-sm text-status-waiting">
+          This document has comments. Editing here rewrites it from its values, which drops them; use the TOML view to
+          keep them.
+        </p>
+      )}
+
+      <div className="space-y-3">
+        <h3 className="font-mono text-xs uppercase tracking-wider text-text-muted">Projects</h3>
+        <p className="text-sm text-text-secondary">
+          Cloned into every workspace on its next start. Addressed by git remote, not by path, because an admin's local
+          checkout means nothing in a container. An existing checkout is left alone, so no user loses uncommitted work.
+        </p>
+
+        {projects.length === 0 && <p className="text-sm text-text-muted">No projects. Workspaces start empty.</p>}
+
+        {projects.map((row, i) => (
+          <div key={i} className="flex flex-wrap items-end gap-2">
+            <label className="flex-1 space-y-1">
+              <span className="text-xs text-text-muted">Name</span>
+              <Input
+                value={row.name}
+                disabled={disabled}
+                placeholder="my-repo"
+                onChange={(e) => setProject(i, { name: e.target.value })}
+              />
+            </label>
+            <label className="flex-[2] space-y-1">
+              <span className="text-xs text-text-muted">Git remote</span>
+              <Input
+                value={row.remote}
+                disabled={disabled}
+                placeholder="https://github.com/org/my-repo.git"
+                onChange={(e) => setProject(i, { remote: e.target.value })}
+              />
+            </label>
+            <label className="flex-1 space-y-1">
+              <span className="text-xs text-text-muted">Base branch</span>
+              <Input
+                value={row.default_base_branch}
+                disabled={disabled}
+                placeholder="detected"
+                onChange={(e) => setProject(i, { default_base_branch: e.target.value })}
+              />
+            </label>
+            <Button
+              type="button"
+              variant="danger"
+              disabled={disabled}
+              aria-label={`Remove project ${row.name || i + 1}`}
+              onClick={() => setProjects(projects.filter((_, j) => j !== i))}
+            >
+              Remove
+            </Button>
+          </div>
+        ))}
+
+        <Button
+          type="button"
+          disabled={disabled}
+          onClick={() => setProjects([...projects, { name: "", remote: "", default_base_branch: "", extra: {} }])}
+        >
+          Add project
+        </Button>
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="font-mono text-xs uppercase tracking-wider text-text-muted">Settings</h3>
+        <p className="text-sm text-text-secondary">
+          The settings worth choosing without an aoe install in front of you. CityHall cannot see which aoe version a
+          workspace runs, so it does not try to render every field: anything not here belongs in the TOML view, and the
+          Settings &rarr; CityHall page of an aoe install generates a complete document for you.
+        </p>
+
+        {FIELDS.map((f) => (
+          <SettingRow
+            key={`${f.section}.${f.field}`}
+            field={f}
+            value={readSetting(doc, f)}
+            disabled={disabled}
+            onChange={(value) => onChange(writeSetting(doc, f, value))}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/// One settings leaf. Every control carries an explicit "aoe default" state,
+/// because an absent key and a key set to the default are not the same thing:
+/// the first follows whatever the workspace's aoe build does, the second pins
+/// it. A plain checkbox could not express the difference.
+function SettingRow({
+  field,
+  value,
+  disabled,
+  onChange,
+}: {
+  field: FormField;
+  value: unknown;
+  disabled: boolean;
+  onChange: (value: unknown) => void;
+}) {
+  const control = () => {
+    switch (field.kind) {
+      case "toggle":
+        return (
+          <Select
+            value={value === undefined ? "" : String(Boolean(value))}
+            disabled={disabled}
+            onChange={(e) => onChange(e.target.value === "" ? undefined : e.target.value === "true")}
+          >
+            <option value="">Use aoe default</option>
+            <option value="true">On</option>
+            <option value="false">Off</option>
+          </Select>
+        );
+      case "select":
+        return (
+          <Select
+            value={value === undefined ? "" : String(value)}
+            disabled={disabled}
+            onChange={(e) => onChange(e.target.value === "" ? undefined : e.target.value)}
+          >
+            <option value="">Use aoe default</option>
+            {field.options.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </Select>
+        );
+      case "number":
+        return (
+          <Input
+            type="number"
+            min={field.min}
+            value={value === undefined ? "" : String(value)}
+            disabled={disabled}
+            placeholder="aoe default"
+            onChange={(e) => onChange(e.target.value === "" ? undefined : Number(e.target.value))}
+          />
+        );
+      case "text":
+        return (
+          <Input
+            value={value === undefined ? "" : String(value)}
+            disabled={disabled}
+            placeholder={`${field.placeholder} (aoe default)`}
+            onChange={(e) => onChange(e.target.value === "" ? undefined : e.target.value)}
+          />
+        );
+    }
+  };
+
+  return (
+    <label className="flex flex-wrap items-start gap-3 border-t border-surface-800 pt-3">
+      <span className="min-w-48 flex-1 space-y-0.5">
+        <span className="block text-sm text-text-primary">{field.label}</span>
+        <span className="block text-xs text-text-muted">{field.description}</span>
+        <code className="block text-xs text-text-muted">
+          settings.{field.section}.{field.field}
+        </code>
+      </span>
+      <span className="w-64">{control()}</span>
+    </label>
   );
 }

--- a/web/src/lib/bundleForm.test.ts
+++ b/web/src/lib/bundleForm.test.ts
@@ -1,0 +1,106 @@
+// Contract test for the form's view of the bundle. The form renders a curated
+// subset of aoe's settings, so the thing that has to hold is that editing
+// through it never drops what it does not render (#45).
+
+import { describe, expect, it } from "vitest";
+import {
+  FIELDS,
+  parseBundle,
+  readProjects,
+  readSetting,
+  settingsCount,
+  stringifyBundle,
+  writeProjects,
+  writeSetting,
+  type Doc,
+} from "./bundleForm";
+
+const field = (section: string, name: string) => FIELDS.find((f) => f.section === section && f.field === name)!;
+
+/// A section the form does not render, a `[meta]` block, and a project carrying
+/// an extra key: everything an edit could silently discard.
+const RICH = `schema_version = 1
+
+[meta]
+generated_by = "aoe v1.13.2"
+
+[settings.acp]
+default_agent = "claude-code"
+
+[settings.logging]
+level = "debug"
+
+[[projects]]
+name = "demo"
+remote = "https://example.com/demo.git"
+some_future_key = 7
+`;
+
+function doc(text: string): Doc {
+  const parsed = parseBundle(text);
+  if ("error" in parsed) throw new Error(parsed.error);
+  return parsed.doc;
+}
+
+/// Every key must be reachable through the same path aoe validates, so a typo
+/// here would only surface as a rejected bundle at workspace boot.
+describe("bundleForm", () => {
+  it("keeps what it does not render when a rendered field is edited", () => {
+    const edited = writeSetting(doc(RICH), field("session", "yolo_mode_default"), true);
+    const out = doc(stringifyBundle(edited));
+
+    expect(readSetting(out, field("session", "yolo_mode_default"))).toBe(true);
+    // Untouched: a whole section with no form row, and the generated-by block.
+    expect((out.settings as Doc).logging).toEqual({ level: "debug" });
+    expect(out.meta).toEqual({ generated_by: "aoe v1.13.2" });
+    expect(readSetting(out, field("acp", "default_agent"))).toBe("claude-code");
+  });
+
+  it("keeps a project key it has no row for", () => {
+    const rows = readProjects(doc(RICH));
+    rows[0].remote = "https://example.com/renamed.git";
+    const out = doc(stringifyBundle(writeProjects(doc(RICH), rows)));
+
+    expect(out.projects).toEqual([{ name: "demo", remote: "https://example.com/renamed.git", some_future_key: 7 }]);
+  });
+
+  it("prunes a section and [settings] once the last override is cleared", () => {
+    let d = doc('schema_version = 1\n\n[settings.acp]\ndefault_agent = "gemini"\n');
+    d = writeSetting(d, field("acp", "default_agent"), undefined);
+
+    expect(d.settings).toBeUndefined();
+    expect(settingsCount(d)).toBe(0);
+    expect(stringifyBundle(d).trim()).toBe("schema_version = 1");
+  });
+
+  it("counts overrides the form does not render", () => {
+    // 1 acp + 1 logging: the summary must not read as "1 setting" just because
+    // only one of them has a form row.
+    expect(settingsCount(doc(RICH))).toBe(2);
+  });
+
+  it("writes schema_version into a document that has none", () => {
+    const out = stringifyBundle(writeSetting({}, field("acp", "default_agent"), "gemini"));
+    expect(doc(out).schema_version).toBe(1);
+  });
+
+  it("drops an empty base branch rather than writing one aoe rejects", () => {
+    const written = writeProjects({}, [
+      { name: "a", remote: "r", default_base_branch: "", extra: {} },
+      { name: "b", remote: "r", default_base_branch: "main", extra: {} },
+    ]);
+    expect(written.projects).toEqual([
+      { name: "a", remote: "r" },
+      { name: "b", remote: "r", default_base_branch: "main" },
+    ]);
+  });
+
+  it("reports a document the form cannot edit instead of treating it as empty", () => {
+    const cases = ["schema_version = ", "[[projects]\nname = 1", "= 3"];
+    for (const bad of cases) {
+      expect(parseBundle(bad)).toHaveProperty("error");
+    }
+    // Valid TOML, but not a table: parses, and would otherwise look blank.
+    expect(parseBundle("")).toEqual({ doc: {} });
+  });
+});

--- a/web/src/lib/bundleForm.ts
+++ b/web/src/lib/bundleForm.ts
@@ -1,0 +1,212 @@
+/// Structured view over the workspace config bundle (#45).
+///
+/// The TOML text stays canonical: the form parses it, edits the parsed
+/// document, and writes it back. That is what lets the two views switch
+/// without a save in between, and it is why a key the form does not render
+/// survives an edit, since it is still sitting in the parsed object.
+///
+/// Comments do not survive, because `stringify` re-emits the document from
+/// values alone. The form says so; the TOML view is the place to keep prose.
+///
+/// The field list below is CityHall's own, not aoe's `GET /api/settings/schema`.
+/// CityHall has no aoe process to ask, and the aoe version a workspace runs is
+/// per-user, so any schema it cached could describe a version nobody runs. A
+/// curated subset plus the raw editor is honest about that; see #45.
+
+import { parse, stringify } from "smol-toml";
+
+export type Doc = Record<string, unknown>;
+
+/// A settings leaf the form renders. `undefined` as a value means "not
+/// overridden": the key is absent from the document and the workspace uses
+/// whatever the aoe build defaults to.
+export type FormField = {
+  section: string;
+  field: string;
+  label: string;
+  description: string;
+} & (
+  | { kind: "text"; placeholder: string }
+  | { kind: "toggle" }
+  | { kind: "number"; min: number }
+  | { kind: "select"; options: { value: string; label: string }[] }
+);
+
+/// Labels and descriptions are paraphrased from the `#[setting(...)]`
+/// declarations in aoe's `src/session/config.rs`. Keys must match exactly:
+/// aoe's `validate_patch` rejects the whole document on an unknown one, and
+/// that failure only surfaces at workspace boot.
+///
+/// Deliberately short. Every entry has to be worth an admin's attention with no
+/// aoe install in front of them, and it must not be `local_only` in aoe's
+/// schema, because `apply` strips those before merging.
+export const FIELDS: FormField[] = [
+  {
+    section: "acp",
+    field: "default_agent",
+    label: "Default agent",
+    description: "Agent a session uses when none is named, e.g. claude-code, gemini, aoe-agent.",
+    kind: "text",
+    placeholder: "claude-code",
+  },
+  {
+    section: "acp",
+    field: "offer_structured_in_new_session",
+    label: "Offer structured view",
+    description: "Show the structured-view toggle in the new-session dialog. Off in aoe by default.",
+    kind: "toggle",
+  },
+  {
+    section: "session",
+    field: "yolo_mode_default",
+    label: "YOLO mode by default",
+    description: "Start new sessions with the agent's permission prompts skipped.",
+    kind: "toggle",
+  },
+  {
+    section: "session",
+    field: "smart_rename",
+    label: "Smart session rename",
+    description: "Name a new session from its first turn instead of leaving the generated title.",
+    kind: "toggle",
+  },
+  {
+    section: "worktree",
+    field: "enabled",
+    label: "Worktree mode by default",
+    description: "Create new sessions in their own git worktree rather than in the checkout itself.",
+    kind: "toggle",
+  },
+  {
+    section: "worktree",
+    field: "auto_cleanup",
+    label: "Clean up worktrees",
+    description: "Remove a session's worktree when the session is deleted.",
+    kind: "toggle",
+  },
+  {
+    section: "updates",
+    field: "update_check_mode",
+    label: "Update checks",
+    description:
+      "A workspace is replaced by its image, so a user cannot act on an update banner; `off` suits most deployments.",
+    kind: "select",
+    options: [
+      { value: "notify", label: "Notify" },
+      { value: "auto", label: "Install automatically" },
+      { value: "off", label: "Off" },
+    ],
+  },
+  {
+    section: "acp",
+    field: "replay_events",
+    label: "History cap (events)",
+    description: "Per-session cap on retained agent events, to bound a workspace's disk use. 0 keeps everything.",
+    kind: "number",
+    min: 0,
+  },
+];
+
+/// One `[[projects]]` entry, cloned into every workspace on its next start.
+/// `extra` carries whatever else the entry held, so an edit here does not drop
+/// a key this build does not know about.
+export interface ProjectRow {
+  name: string;
+  remote: string;
+  default_base_branch: string;
+  extra: Doc;
+}
+
+export function parseBundle(text: string): { doc: Doc } | { error: string } {
+  if (!text.trim()) return { doc: {} };
+  try {
+    const doc = parse(text);
+    // A top-level array or scalar parses fine as TOML but is not a bundle, and
+    // the form would silently treat it as empty.
+    if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
+      return { error: "the document is not a TOML table" };
+    }
+    return { doc: doc as Doc };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : "the document is not valid TOML" };
+  }
+}
+
+export function stringifyBundle(doc: Doc): string {
+  // `schema_version` is what the server checks first, and a document written
+  // from the form has no other way to acquire it.
+  const withVersion = "schema_version" in doc ? doc : { schema_version: 1, ...doc };
+  return `${stringify(withVersion)}\n`;
+}
+
+function table(doc: Doc, key: string): Doc | undefined {
+  const value = doc[key];
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Doc) : undefined;
+}
+
+export function readSetting(doc: Doc, f: FormField): unknown {
+  return table(table(doc, "settings") ?? {}, f.section)?.[f.field];
+}
+
+/// Set a settings leaf, or remove it when `value` is `undefined`.
+///
+/// Removal prunes the section and the `[settings]` table once they are empty,
+/// so clearing every override leaves a document that overrides nothing rather
+/// than one carrying empty tables that read as configuration.
+export function writeSetting(doc: Doc, f: FormField, value: unknown): Doc {
+  const settings = { ...(table(doc, "settings") ?? {}) };
+  const section = { ...(table(settings, f.section) ?? {}) };
+
+  if (value === undefined) delete section[f.field];
+  else section[f.field] = value;
+
+  if (Object.keys(section).length > 0) settings[f.section] = section;
+  else delete settings[f.section];
+
+  const next = { ...doc };
+  if (Object.keys(settings).length > 0) next.settings = settings;
+  else delete next.settings;
+  return next;
+}
+
+/// How many settings leaves the document overrides, including sections the
+/// form does not render.
+export function settingsCount(doc: Doc): number {
+  const settings = table(doc, "settings") ?? {};
+  return Object.keys(settings).reduce((n, key) => n + Object.keys(table(settings, key) ?? {}).length, 0);
+}
+
+function rawProjects(doc: Doc): Doc[] {
+  const value = doc.projects;
+  if (!Array.isArray(value)) return [];
+  return value.filter((p): p is Doc => typeof p === "object" && p !== null && !Array.isArray(p));
+}
+
+export function readProjects(doc: Doc): ProjectRow[] {
+  return rawProjects(doc).map((p) => {
+    const { name, remote, default_base_branch, ...extra } = p;
+    return {
+      name: typeof name === "string" ? name : "",
+      remote: typeof remote === "string" ? remote : "",
+      default_base_branch: typeof default_base_branch === "string" ? default_base_branch : "",
+      extra,
+    };
+  });
+}
+
+export function writeProjects(doc: Doc, rows: ProjectRow[]): Doc {
+  const next = { ...doc };
+  if (rows.length === 0) {
+    delete next.projects;
+    return next;
+  }
+  next.projects = rows.map(({ name, remote, default_base_branch, extra }) => ({
+    ...extra,
+    name,
+    remote,
+    // Absent means "use whatever the repo's default branch is", which is not
+    // the same as an empty string, and aoe validates it as a non-empty name.
+    ...(default_base_branch ? { default_base_branch } : {}),
+  }));
+  return next;
+}


### PR DESCRIPTION
## Description

The form editor for the workspace config bundle (#51, closing #45) is not in `main`, so **Settings → Workspace config** still shows only the raw TOML textarea. This lands it.

#51 was merged into `cityhall-config-bundle`. That branch had already been squash-merged into `main` a day earlier as `81d4551` (#46), which collapsed its six commits into one under a new sha. #51 then landed on the original branch, after the squash, so its work never reached `main` even though the PR shows as merged and #45 was closed as completed.

Because the six older commits are content-identical to what `81d4551` already contains, the diff here is exactly #51's work and nothing else:

- `web/src/lib/bundleForm.ts` and `web/src/lib/bundleForm.test.ts`, new
- `web/src/components/WorkspaceConfig.tsx`, the Form view alongside the existing TOML view
- `smol-toml` added to `web/package.json`
- `docs/workspaces.md` updated

No code is authored here. This is the same commit (`974fd4d`), reachable from a branch whose base was already merged.

**Suggested merge strategy: squash.** A merge commit would add six commits to `main` whose content is already there, each with an empty diff. A squash lands one commit carrying only the form change.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] Open **Settings → Workspace config** and confirm a Form view is offered alongside the TOML view.
- [ ] Switch between the two views without saving in between and confirm the document survives the round trip.
- [ ] Confirm a key the form does not render (a `[meta]` table, a `[settings.logging]` section, an extra key on a project) survives a form edit and a save.

## Checklist

- [x] New and existing tests pass
- [ ] `cargo fmt` / `cargo clippy` clean (API changes)
- [x] `npm run lint` / `npm run format:check` clean (web changes)
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code)

The change itself is from #51 and predates this PR. Claude diagnosed why it was missing from `main`, confirmed the diff against `main` contains only #51's work, and opened this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace configuration bundles with TOML editing, validation, summaries, uploads, and structured form controls.
  * Added per-user Git credential management with secure storage and token preservation.
  * Workspaces now receive configuration automatically at startup.
  * Added an Account page for credential settings and navigation from the user menu.
* **Documentation**
  * Documented configuration bundle formats, editing behavior, delivery, validation, and Git credential handling.
* **Bug Fixes**
  * Added support for safely backfilling configuration access for existing workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->