### PR TITLE
feat(workspaces): admin-level aoe telemetry policy for every workspace

### DIFF
--- a/api/src/entities/workspace_settings.rs
+++ b/api/src/entities/workspace_settings.rs
@@ -14,6 +14,11 @@ pub struct Model {
     /// unset.
     pub default_version: Option<String>,
     pub idle_stop_minutes: i32,
+    /// Deployment-wide aoe telemetry policy, as one of
+    /// [`crate::orchestrator::TelemetryPolicy`]'s wire values. Kept as a string
+    /// here so a value written by a newer CityHall round-trips through an older
+    /// one instead of failing the whole row's deserialization.
+    pub telemetry_policy: String,
     pub updated_at: DateTimeUtc,
 }
 

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use crate::auth::AuthUser;
 use crate::entities::{workspace, workspace_settings};
 use crate::error::AppError;
-use crate::orchestrator::{binary_key, render_image, WorkspaceStatus};
+use crate::orchestrator::{
+    binary_key, render_image, telemetry_policy_override, TelemetryPolicy, WorkspaceStatus,
+};
 use crate::proxy;
 use crate::state::AppState;
 use crate::workspaces::{self, SETTINGS_ID};
@@ -321,6 +323,16 @@ pub struct WorkspaceSettingsResponse {
     pub image_template: String,
     pub default_version: Option<String>,
     pub idle_stop_minutes: i32,
+    /// The stored telemetry policy, which is what a save writes and what takes
+    /// effect once any override is removed.
+    pub telemetry_policy: &'static str,
+    /// The deployment-level override, when `WORKSPACE_TELEMETRY_POLICY` is set.
+    /// Reported separately from the stored value so the page can say the policy
+    /// is pinned by the environment instead of showing a control that silently
+    /// does nothing.
+    pub telemetry_policy_override: Option<&'static str>,
+    /// What workspaces actually run under: the override, or the stored value.
+    pub effective_telemetry_policy: &'static str,
 }
 
 #[derive(Deserialize)]
@@ -328,6 +340,13 @@ pub struct UpdateWorkspaceSettingsRequest {
     pub image_template: String,
     pub default_version: Option<String>,
     pub idle_stop_minutes: i32,
+    pub telemetry_policy: String,
+    /// Recreate every RUNNING workspace so the saved policy applies now.
+    /// Off by default, and the same opt-in the version rollout uses: a recreate
+    /// ends whatever the user is running. Stopped workspaces do not need it;
+    /// they come back on the new policy at their next start.
+    #[serde(default)]
+    pub restart_running: bool,
 }
 
 /// GET /api/settings/workspaces
@@ -337,7 +356,13 @@ pub async fn get_settings(
 ) -> Result<Json<WorkspaceSettingsResponse>, AppError> {
     caller.require("settings.read")?;
     let cfg = workspaces::settings(&state.db).await?;
+    // Unwrapped rather than propagated: an invalid override already failed
+    // CityHall's startup, so this cannot be an error by the time a request runs.
+    let policy_override = telemetry_policy_override().unwrap_or_default();
     Ok(Json(WorkspaceSettingsResponse {
+        telemetry_policy: TelemetryPolicy::from_stored(&cfg.telemetry_policy).as_str(),
+        telemetry_policy_override: policy_override.map(TelemetryPolicy::as_str),
+        effective_telemetry_policy: workspaces::effective_telemetry_policy(&cfg).as_str(),
         image_template: cfg.image_template,
         default_version: cfg.default_version,
         idle_stop_minutes: cfg.idle_stop_minutes,
@@ -357,6 +382,11 @@ pub async fn update_settings(
     if body.idle_stop_minutes < 1 {
         return Err(AppError::BadRequest("idle stop must be at least 1 minute"));
     }
+    // Rejected rather than coerced: silently storing `user_choice` for a value
+    // the admin thought forced telemetry off is the failure worth avoiding.
+    let telemetry_policy = TelemetryPolicy::parse(&body.telemetry_policy).ok_or(
+        AppError::BadRequest("telemetry policy must be user_choice, force_on, or force_off"),
+    )?;
     let default_version = normalize(body.default_version);
 
     let existing = workspace_settings::Entity::find_by_id(SETTINGS_ID)
@@ -367,12 +397,22 @@ pub async fn update_settings(
         image_template: Set(body.image_template.trim().to_string()),
         default_version: Set(default_version),
         idle_stop_minutes: Set(body.idle_stop_minutes),
+        telemetry_policy: Set(telemetry_policy.as_str().to_string()),
         updated_at: Set(Utc::now()),
     };
     if existing.is_some() {
         model.update(&state.db).await?;
     } else {
         model.insert(&state.db).await?;
+    }
+    if body.restart_running {
+        let user_ids = workspace::Entity::find()
+            .all(&state.db)
+            .await?
+            .into_iter()
+            .map(|r| r.user_id)
+            .collect();
+        spawn_restarts(state.clone(), user_ids);
     }
     get_settings(State(state), caller).await
 }

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -323,9 +323,13 @@ pub struct WorkspaceSettingsResponse {
     pub image_template: String,
     pub default_version: Option<String>,
     pub idle_stop_minutes: i32,
-    /// The stored telemetry policy, which is what a save writes and what takes
-    /// effect once any override is removed.
-    pub telemetry_policy: &'static str,
+    /// The stored telemetry policy, verbatim, which is what takes effect once any
+    /// override is removed.
+    ///
+    /// Raw rather than parsed, so a value only a newer CityHall understands can
+    /// be echoed back on a save and survive it (see [`policy_to_store`]).
+    /// `effective_telemetry_policy` is where such a value reads as `user_choice`.
+    pub telemetry_policy: String,
     /// The deployment-level override, when `WORKSPACE_TELEMETRY_POLICY` is set.
     /// Reported separately from the stored value so the page can say the policy
     /// is pinned by the environment instead of showing a control that silently
@@ -349,6 +353,29 @@ pub struct UpdateWorkspaceSettingsRequest {
     pub restart_running: bool,
 }
 
+/// The telemetry policy value a save should store.
+///
+/// A submitted value identical to what is already stored is a retention, not a
+/// choice, and is kept verbatim. That is what stops a save made by an older
+/// CityHall from flattening a policy a newer one wrote: this build reads such a
+/// value as `user_choice` and shows it that way, but it never overwrites it
+/// unless the admin actually picks something else.
+///
+/// Anything else is an explicit selection, so it has to be a policy this build
+/// knows. Rejected rather than coerced: silently storing `user_choice` for a
+/// value the admin believed forced telemetry off is the failure worth avoiding.
+fn policy_to_store(submitted: &str, stored: Option<&str>) -> Result<String, AppError> {
+    let submitted = submitted.trim();
+    if stored == Some(submitted) {
+        return Ok(submitted.to_string());
+    }
+    TelemetryPolicy::parse(submitted)
+        .map(|policy| policy.as_str().to_string())
+        .ok_or(AppError::BadRequest(
+            "telemetry policy must be user_choice, force_on, or force_off",
+        ))
+}
+
 /// GET /api/settings/workspaces
 pub async fn get_settings(
     State(state): State<AppState>,
@@ -360,9 +387,9 @@ pub async fn get_settings(
     // CityHall's startup, so this cannot be an error by the time a request runs.
     let policy_override = telemetry_policy_override().unwrap_or_default();
     Ok(Json(WorkspaceSettingsResponse {
-        telemetry_policy: TelemetryPolicy::from_stored(&cfg.telemetry_policy).as_str(),
         telemetry_policy_override: policy_override.map(TelemetryPolicy::as_str),
         effective_telemetry_policy: workspaces::effective_telemetry_policy(&cfg).as_str(),
+        telemetry_policy: cfg.telemetry_policy,
         image_template: cfg.image_template,
         default_version: cfg.default_version,
         idle_stop_minutes: cfg.idle_stop_minutes,
@@ -382,22 +409,21 @@ pub async fn update_settings(
     if body.idle_stop_minutes < 1 {
         return Err(AppError::BadRequest("idle stop must be at least 1 minute"));
     }
-    // Rejected rather than coerced: silently storing `user_choice` for a value
-    // the admin thought forced telemetry off is the failure worth avoiding.
-    let telemetry_policy = TelemetryPolicy::parse(&body.telemetry_policy).ok_or(
-        AppError::BadRequest("telemetry policy must be user_choice, force_on, or force_off"),
-    )?;
     let default_version = normalize(body.default_version);
 
     let existing = workspace_settings::Entity::find_by_id(SETTINGS_ID)
         .one(&state.db)
         .await?;
+    let telemetry_policy = policy_to_store(
+        &body.telemetry_policy,
+        existing.as_ref().map(|r| r.telemetry_policy.as_str()),
+    )?;
     let model = workspace_settings::ActiveModel {
         id: Set(SETTINGS_ID),
         image_template: Set(body.image_template.trim().to_string()),
         default_version: Set(default_version),
         idle_stop_minutes: Set(body.idle_stop_minutes),
-        telemetry_policy: Set(telemetry_policy.as_str().to_string()),
+        telemetry_policy: Set(telemetry_policy),
         updated_at: Set(Utc::now()),
     };
     if existing.is_some() {
@@ -415,4 +441,44 @@ pub async fn update_settings(
         spawn_restarts(state.clone(), user_ids);
     }
     get_settings(State(state), caller).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole point of keeping the stored policy a raw string: an admin on an
+    /// older CityHall, which reads a policy it does not know as `user_choice`,
+    /// must not flatten it just by saving the settings form.
+    #[test]
+    fn an_unknown_stored_policy_survives_a_save_that_does_not_change_it() {
+        assert_eq!(
+            policy_to_store("force_maybe", Some("force_maybe")).unwrap(),
+            "force_maybe"
+        );
+    }
+
+    /// Choosing a policy this build knows replaces whatever was there.
+    #[test]
+    fn an_explicit_choice_replaces_the_stored_value() {
+        assert_eq!(
+            policy_to_store("force_off", Some("force_maybe")).unwrap(),
+            "force_off"
+        );
+        assert_eq!(
+            policy_to_store(" force_on ", Some("user_choice")).unwrap(),
+            "force_on"
+        );
+    }
+
+    /// An unknown value that is not simply what is already stored has no
+    /// provenance to preserve, so it is a bad request rather than a way to write
+    /// arbitrary strings into the column.
+    #[test]
+    fn an_unknown_value_cannot_be_introduced() {
+        assert!(policy_to_store("force_maybe", Some("user_choice")).is_err());
+        // Including on the very first save, when there is no row yet.
+        assert!(policy_to_store("force_maybe", None).is_err());
+        assert!(policy_to_store("", None).is_err());
+    }
 }

--- a/api/src/migration/m0011_create_workspaces.rs
+++ b/api/src/migration/m0011_create_workspaces.rs
@@ -79,4 +79,6 @@ pub enum WorkspaceSettings {
     DefaultVersion,
     IdleStopMinutes,
     UpdatedAt,
+    /// Added by m0015; declared here so the iden stays with its table.
+    TelemetryPolicy,
 }

--- a/api/src/migration/m0015_add_workspace_telemetry_policy.rs
+++ b/api/src/migration/m0015_add_workspace_telemetry_policy.rs
@@ -1,0 +1,40 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::schema::*;
+
+use super::m0011_create_workspaces::WorkspaceSettings;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Deployment-wide aoe telemetry policy: `user_choice`, `force_on`, or
+        // `force_off` (#40). Text rather than an enum type: SQLite has none, and
+        // the values are validated at the Rust boundary anyway.
+        //
+        // `user_choice` is the default so an upgrade changes nothing. A stored
+        // value is what an admin intended; a value the running CityHall does not
+        // recognize is read as `user_choice`, which is the state that touches
+        // nothing rather than one that forces a decision on every user.
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WorkspaceSettings::Table)
+                    .add_column(string(WorkspaceSettings::TelemetryPolicy).default("user_choice"))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WorkspaceSettings::Table)
+                    .drop_column(WorkspaceSettings::TelemetryPolicy)
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/api/src/migration/mod.rs
+++ b/api/src/migration/mod.rs
@@ -14,6 +14,7 @@ mod m0011_create_workspaces;
 mod m0012_create_workspace_config;
 mod m0013_create_agent_credentials;
 mod m0014_create_git_ssh_keys;
+mod m0015_add_workspace_telemetry_policy;
 
 pub struct Migrator;
 
@@ -35,6 +36,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0012_create_workspace_config::Migration),
             Box::new(m0013_create_agent_credentials::Migration),
             Box::new(m0014_create_git_ssh_keys::Migration),
+            Box::new(m0015_add_workspace_telemetry_policy::Migration),
         ]
     }
 }

--- a/api/src/orchestrator/docker.rs
+++ b/api/src/orchestrator/docker.rs
@@ -22,7 +22,7 @@ use tokio::process::Command;
 
 use super::{
     proxy_allowed_host, proxy_allowed_origin, wait_ready, Begin, Orchestrator, OrchestratorError,
-    ProvisioningRegistry, WorkspaceSpec, WorkspaceStatus,
+    ProvisioningRegistry, TelemetryPolicy, WorkspaceSpec, WorkspaceStatus,
 };
 
 /// Port aoe serves on inside the workspace container.
@@ -112,6 +112,7 @@ impl DockerCliOrchestrator {
                     version_label: labels.get("cityhall.workspace.version").cloned(),
                     network_label: labels.get("cityhall.workspace.network").cloned(),
                     env_label: labels.get("cityhall.workspace.env").cloned(),
+                    telemetry_label: labels.get("cityhall.workspace.telemetry").cloned(),
                 }))
             }
             None => Ok(None),
@@ -352,15 +353,22 @@ fn log_tail(path: &std::path::Path) -> String {
 }
 
 /// `KEY=value` lines for everything the workspace's environment needs: the
-/// bundle location and token (when configured), then every agent credential.
-/// One line per pair, in that order; `agent_credentials::validate_value`
-/// guarantees a value can contain no NUL, newline, or carriage return before
-/// it ever reaches here, which this line-oriented format depends on.
+/// bundle location and token (when configured), the telemetry policy's own
+/// variables, then every agent credential. One line per pair, in that order;
+/// `agent_credentials::validate_value` guarantees a value can contain no NUL,
+/// newline, or carriage return before it ever reaches here, which this
+/// line-oriented format depends on.
+///
+/// The policy's variables are not secret, but they ride the same file rather
+/// than a second `-e` mechanism: one place builds this container's environment.
 fn env_file_contents(spec: &WorkspaceSpec) -> String {
     let mut out = String::new();
     if let Some(bundle) = &spec.bundle {
         out.push_str(&format!("AOE_CITYHALL_BUNDLE_URL={}\n", bundle.url));
         out.push_str(&format!("AOE_CITYHALL_BUNDLE_TOKEN={}\n", bundle.token));
+    }
+    for (name, value) in spec.telemetry.env_pairs() {
+        out.push_str(&format!("{name}={value}\n"));
     }
     for (name, value) in &spec.agent_env.pairs {
         out.push_str(&format!("{name}={}\n", value.expose()));
@@ -451,6 +459,11 @@ fn run_args(spec: &WorkspaceSpec, network: Option<&str>, env_file: Option<&Path>
         // absent label compare equal and neither is treated as drift.
         "--label".into(),
         format!("cityhall.workspace.env={}", spec.agent_env.fingerprint),
+        // Its own label rather than folded into the env fingerprint above: an
+        // operator inspecting a container should be able to read the policy it
+        // runs under, and a policy change is not a credential change.
+        "--label".into(),
+        format!("cityhall.workspace.telemetry={}", spec.telemetry.as_str()),
         "-v".into(),
         format!("{volume}:{AOE_DATA_DIR}"),
     ];
@@ -478,31 +491,37 @@ fn run_args(spec: &WorkspaceSpec, network: Option<&str>, env_file: Option<&Path>
         args.push("--env-file".into());
         args.push(path.display().to_string());
     }
+    args.push(spec.image.clone());
+    // The image's ENTRYPOINT stays in charge (it is what puts each agent's
+    // config on the volume); this is only the command it execs, which force-on
+    // wraps to assert the telemetry policy first.
     args.extend(
-        [
-            &spec.image,
-            "aoe",
-            "serve",
-            "--host",
-            "0.0.0.0",
-            "--port",
-            &AOE_PORT.to_string(),
-            // CityHall's session gates the proxy; the container port is never
-            // reachable from outside (loopback publish or internal network).
-            "--auth",
-            "none",
-            "--behind-proxy",
-            // The proxy forwards the public Host and Origin, both of which
-            // aoe's DNS-rebinding gate requires on the allowlist.
-            "--allowed-host",
-            &proxy_allowed_host(),
-            "--allowed-origin",
-            &proxy_allowed_origin(),
-            // Locked-down end-user client: composer + structured view only.
-            "--cityhall",
-        ]
-        .iter()
-        .map(|s| s.to_string()),
+        spec.telemetry.wrap_command(
+            [
+                "aoe",
+                "serve",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                &AOE_PORT.to_string(),
+                // CityHall's session gates the proxy; the container port is never
+                // reachable from outside (loopback publish or internal network).
+                "--auth",
+                "none",
+                "--behind-proxy",
+                // The proxy forwards the public Host and Origin, both of which
+                // aoe's DNS-rebinding gate requires on the allowlist.
+                "--allowed-host",
+                &proxy_allowed_host(),
+                "--allowed-origin",
+                &proxy_allowed_origin(),
+                // Locked-down end-user client: composer + structured view only.
+                "--cityhall",
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        ),
     );
     args
 }
@@ -569,22 +588,36 @@ struct ContainerState {
     version_label: Option<String>,
     network_label: Option<String>,
     env_label: Option<String>,
+    telemetry_label: Option<String>,
 }
 
 /// Whether a running container must be recreated rather than reused or
-/// resumed: the pinned version changed, the addressing mode changed, or the
-/// injected credential set changed. Extracted as a pure function so the
-/// credential-drift condition (the part this feature adds) is testable
-/// without a docker daemon.
+/// resumed: the pinned version changed, the addressing mode changed, the
+/// injected credential set changed, or the telemetry policy changed. Extracted
+/// as a pure function so the drift conditions are testable without a docker
+/// daemon.
 ///
-/// The env label is absent on any container created before this feature.
-/// Treating that absence as the empty string means a user with no stored
-/// credentials (whose fingerprint is also empty) is never recreated on
-/// upgrade just because the label didn't exist yet.
+/// The env label is absent on any container created before credentials were
+/// injected. Treating that absence as the empty string means a user with no
+/// stored credentials (whose fingerprint is also empty) is never recreated on
+/// upgrade just because the label didn't exist yet. The telemetry label is
+/// absent for the same reason and reads as `user_choice`, which is what a
+/// container created before the policy existed effectively runs under, so
+/// again nothing is recreated by the upgrade alone.
+///
+/// The policy has to be here and not only in the create path: a stopped
+/// container is otherwise resumed with `docker start`, which reuses its stored
+/// environment, and a policy change would never reach it.
 fn needs_recreate(state: &ContainerState, spec: &WorkspaceSpec, network: Option<&str>) -> bool {
+    let telemetry = state
+        .telemetry_label
+        .as_deref()
+        .map(TelemetryPolicy::from_stored)
+        .unwrap_or_default();
     state.version_label.as_deref() != Some(spec.version.as_str())
         || state.network_label.as_deref() != network
         || state.env_label.as_deref().unwrap_or("") != spec.agent_env.fingerprint
+        || telemetry != spec.telemetry
 }
 
 #[derive(Deserialize)]
@@ -658,6 +691,7 @@ mod tests {
             version: "v1.0.0".to_string(),
             bundle: None,
             agent_env: crate::agent_credentials::AgentEnv::default(),
+            telemetry: TelemetryPolicy::default(),
         }
     }
 
@@ -789,6 +823,89 @@ mod tests {
             .any(|a| a == "cityhall.workspace.network=cityhall-workspaces"));
     }
 
+    fn spec_with_telemetry(policy: TelemetryPolicy) -> WorkspaceSpec {
+        WorkspaceSpec {
+            telemetry: policy,
+            ..spec()
+        }
+    }
+
+    /// Force-off is delivered as `DO_NOT_TRACK`, which aoe treats as absolute,
+    /// and leaves the command alone. The other two policies inject nothing.
+    #[test]
+    fn only_force_off_puts_do_not_track_in_the_env_file() {
+        let contents = env_file_contents(&spec_with_telemetry(TelemetryPolicy::ForceOff));
+        assert_eq!(contents, "DO_NOT_TRACK=1\n");
+        for policy in [TelemetryPolicy::UserChoice, TelemetryPolicy::ForceOn] {
+            assert!(env_file_contents(&spec_with_telemetry(policy)).is_empty());
+        }
+    }
+
+    /// Force-on runs aoe's own CLI first, so aoe records the opt-in (and the
+    /// answered consent that suppresses its modal) in the volume. The wrapper
+    /// goes after the image, so it is the container's command, and the image's
+    /// ENTRYPOINT still runs first.
+    #[test]
+    fn force_on_wraps_the_container_command_after_the_image() {
+        let args = run_args(&spec_with_telemetry(TelemetryPolicy::ForceOn), None, None);
+        let image_at = args
+            .iter()
+            .position(|a| a == "cityhall/aoe:v1.0.0")
+            .unwrap();
+        assert_eq!(args[image_at + 1], "sh");
+        assert_eq!(args[image_at + 2], "-c");
+        assert!(args[image_at + 3].contains("aoe telemetry enable"));
+        // The serve command survives as separate argv elements, not a string.
+        assert_eq!(args[image_at + 4], "aoe");
+        assert_eq!(args[image_at + 5], "serve");
+        assert!(args.iter().any(|a| a == "--cityhall"));
+
+        // The other policies leave the command exactly as it was.
+        let plain = run_args(&spec(), None, None);
+        assert!(!plain.iter().any(|a| a == "sh"), "{plain:?}");
+    }
+
+    #[test]
+    fn the_policy_is_recorded_on_the_container() {
+        let args = run_args(&spec_with_telemetry(TelemetryPolicy::ForceOff), None, None);
+        assert!(args
+            .iter()
+            .any(|a| a == "cityhall.workspace.telemetry=force_off"));
+    }
+
+    /// A container created before the policy existed has no telemetry label,
+    /// which reads as `user_choice`: what it is in fact running under. So the
+    /// upgrade alone recreates nothing, while an actual policy change does, and
+    /// it has to, because a stopped container would otherwise be resumed with
+    /// `docker start` and its old environment.
+    #[test]
+    fn telemetry_policy_change_is_drift_but_the_upgrade_alone_is_not() {
+        let state = container_state("v1.0.0", None, None);
+        assert!(!needs_recreate(&state, &spec(), None));
+        assert!(needs_recreate(
+            &state,
+            &spec_with_telemetry(TelemetryPolicy::ForceOff),
+            None
+        ));
+
+        let forced = ContainerState {
+            telemetry_label: Some("force_off".to_string()),
+            ..container_state("v1.0.0", None, None)
+        };
+        assert!(!needs_recreate(
+            &forced,
+            &spec_with_telemetry(TelemetryPolicy::ForceOff),
+            None
+        ));
+        // Including switching between the two forced states, and back.
+        assert!(needs_recreate(
+            &forced,
+            &spec_with_telemetry(TelemetryPolicy::ForceOn),
+            None
+        ));
+        assert!(needs_recreate(&forced, &spec(), None));
+    }
+
     fn container_state(
         version: &str,
         network: Option<&str>,
@@ -799,6 +916,9 @@ mod tests {
             version_label: Some(version.to_string()),
             network_label: network.map(str::to_string),
             env_label: env_label.map(str::to_string),
+            // Absent, like a container created before the policy existed. The
+            // telemetry cases below set it explicitly.
+            telemetry_label: None,
         }
     }
 

--- a/api/src/orchestrator/kubernetes.rs
+++ b/api/src/orchestrator/kubernetes.rs
@@ -18,7 +18,7 @@ use tokio::process::Command;
 
 use super::{
     http_probe, proxy_allowed_host, proxy_allowed_origin, Orchestrator, OrchestratorError,
-    WorkspaceSpec, WorkspaceStatus,
+    TelemetryPolicy, WorkspaceSpec, WorkspaceStatus,
 };
 
 /// Port aoe serves on inside the workspace pod.
@@ -287,6 +287,9 @@ fn env_values(spec: &WorkspaceSpec) -> std::collections::BTreeMap<String, String
             bundle.token.clone(),
         );
     }
+    for (name, value) in spec.telemetry.env_pairs() {
+        values.insert(name.to_string(), value.to_string());
+    }
     for (name, value) in &spec.agent_env.pairs {
         values.insert(name.clone(), value.expose().to_string());
     }
@@ -322,25 +325,26 @@ fn render_manifests(
         // where the reference image relocates each agent's config directory
         // onto the volume. Passing the whole command as `args` instead matches
         // what the docker backend does, and an image with no entrypoint runs
-        // these as the command anyway.
-        "args": [
-            "aoe",
-            "serve",
-            "--host", "0.0.0.0",
-            "--port", AOE_PORT.to_string(),
+        // these as the command anyway. Force-on wraps these args (never the
+        // entrypoint) so the policy is asserted before aoe serves.
+        "args": spec.telemetry.wrap_command(vec![
+            "aoe".to_string(),
+            "serve".to_string(),
+            "--host".to_string(), "0.0.0.0".to_string(),
+            "--port".to_string(), AOE_PORT.to_string(),
             // CityHall's session gates the proxy; the
             // shipped NetworkPolicy keeps other pods out.
-            "--auth", "none",
-            "--behind-proxy",
+            "--auth".to_string(), "none".to_string(),
+            "--behind-proxy".to_string(),
             // The proxy forwards the public Host and
             // Origin, both of which aoe's DNS-rebinding
             // gate requires on the allowlist.
-            "--allowed-host", proxy_allowed_host(),
-            "--allowed-origin", proxy_allowed_origin(),
+            "--allowed-host".to_string(), proxy_allowed_host(),
+            "--allowed-origin".to_string(), proxy_allowed_origin(),
             // Locked-down end-user client: composer +
             // structured view only.
-            "--cityhall",
-        ],
+            "--cityhall".to_string(),
+        ]),
         "ports": [{ "containerPort": AOE_PORT }],
         "volumeMounts": [{ "name": "data", "mountPath": AOE_DATA_DIR }],
     });
@@ -382,6 +386,24 @@ fn render_manifests(
         }));
     }
 
+    let mut annotations = json!({
+        // Version drives pod recreation on apply.
+        "cityhall.workspace.version": spec.version,
+        // Editing the Secret alone does not restart running
+        // pods; changing this annotation changes the pod
+        // template, which is what makes the Deployment roll
+        // to pick up a new credential set.
+        "cityhall.workspace/env-fingerprint": spec.agent_env.fingerprint,
+    });
+    // Same reason as the fingerprint: the policy changes the pod's environment
+    // and args, so the template has to change for the Deployment to roll.
+    // Written only when a policy is actually forced, so deploying this feature
+    // leaves an existing workspace's template byte-identical and does not roll
+    // every pod in the namespace for a setting nobody has touched yet.
+    if spec.telemetry != TelemetryPolicy::UserChoice {
+        annotations["cityhall.workspace/telemetry-policy"] = json!(spec.telemetry.as_str());
+    }
+
     items.push(json!({
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -394,15 +416,7 @@ fn render_manifests(
             "template": {
                 "metadata": {
                     "labels": labels,
-                    "annotations": {
-                        // Version drives pod recreation on apply.
-                        "cityhall.workspace.version": spec.version,
-                        // Editing the Secret alone does not restart running
-                        // pods; changing this annotation changes the pod
-                        // template, which is what makes the Deployment roll
-                        // to pick up a new credential set.
-                        "cityhall.workspace/env-fingerprint": spec.agent_env.fingerprint,
-                    },
+                    "annotations": annotations,
                 },
                 "spec": {
                     "containers": [container],
@@ -475,6 +489,7 @@ mod tests {
             version: "v1.0.0".to_string(),
             bundle: None,
             agent_env: crate::agent_credentials::AgentEnv::default(),
+            telemetry: TelemetryPolicy::default(),
         }
     }
 
@@ -663,6 +678,75 @@ mod tests {
                 ["cityhall.workspace/env-fingerprint"],
             "abc123fingerprint"
         );
+    }
+
+    fn spec_with_telemetry(policy: TelemetryPolicy) -> WorkspaceSpec {
+        WorkspaceSpec {
+            telemetry: policy,
+            ..spec()
+        }
+    }
+
+    fn deployment(policy: TelemetryPolicy) -> serde_json::Value {
+        let m = render_manifests(&spec_with_telemetry(policy), "cityhall", "5Gi", None);
+        m["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|i| i["kind"] == "Deployment")
+            .unwrap()
+            .clone()
+    }
+
+    /// The annotation is what makes the Deployment roll, so it must appear for a
+    /// forced policy and must NOT appear for `user_choice`: writing it there too
+    /// would change every existing workspace's pod template on upgrade and roll
+    /// every pod in the namespace for a setting nobody has touched.
+    #[test]
+    fn only_a_forced_telemetry_policy_annotates_the_pod_template() {
+        let annotations =
+            |policy| deployment(policy)["spec"]["template"]["metadata"]["annotations"].clone();
+        assert!(annotations(TelemetryPolicy::UserChoice)
+            .get("cityhall.workspace/telemetry-policy")
+            .is_none());
+        assert_eq!(
+            annotations(TelemetryPolicy::ForceOn)["cityhall.workspace/telemetry-policy"],
+            "force_on"
+        );
+    }
+
+    /// Force-on wraps the container's args, never its `command`, which would
+    /// take the image's ENTRYPOINT out of the picture. Every serve argument
+    /// stays its own list element.
+    #[test]
+    fn force_on_wraps_the_container_args() {
+        let dep = deployment(TelemetryPolicy::ForceOn);
+        let container = &dep["spec"]["template"]["spec"]["containers"][0];
+        let args = container["args"].as_array().unwrap();
+        assert_eq!(args[0], "sh");
+        assert_eq!(args[1], "-c");
+        assert!(args[2].as_str().unwrap().contains("aoe telemetry enable"));
+        assert_eq!(args[3], "aoe");
+        assert_eq!(args[4], "serve");
+        assert!(container.get("command").is_none());
+    }
+
+    /// Force-off travels as `DO_NOT_TRACK`, so a deployment with no credentials
+    /// and no bundle still needs the Secret that policy rides in.
+    #[test]
+    fn force_off_injects_do_not_track_through_the_secret() {
+        let m = render_manifests(
+            &spec_with_telemetry(TelemetryPolicy::ForceOff),
+            "cityhall",
+            "5Gi",
+            None,
+        );
+        let items = m["items"].as_array().unwrap();
+        let secret = items
+            .iter()
+            .find(|i| i["kind"] == "Secret")
+            .expect("force-off has a variable to inject, so a Secret is emitted");
+        assert_eq!(secret["stringData"]["DO_NOT_TRACK"], "1");
     }
 
     #[test]

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -31,6 +31,129 @@ pub struct WorkspaceSpec {
     /// safe; a bare `Vec<(String, String)>` here would be a leak waiting for a
     /// future tracing call.
     pub agent_env: crate::agent_credentials::AgentEnv,
+    /// The deployment's telemetry policy, applied at every start.
+    pub telemetry: TelemetryPolicy,
+}
+
+/// Who decides whether a workspace sends aoe telemetry (#40).
+///
+/// aoe stores consent per user inside the workspace's own volume, which in a
+/// CityHall deployment puts the decision on a non-technical end user (and shows
+/// them aoe's consent modal, exactly the kind of prompt CityHall client mode
+/// exists to remove). This is the deployment operator's answer instead.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum TelemetryPolicy {
+    /// CityHall injects nothing: aoe's own consent flow reaches the user, and
+    /// nothing marks their consent as answered on their behalf.
+    #[default]
+    UserChoice,
+    /// Telemetry on for everyone. Enforced by running `aoe telemetry enable`
+    /// against the workspace's data before `aoe serve` starts, which is what
+    /// also records the consent as answered and so suppresses the modal.
+    ForceOn,
+    /// Telemetry off for everyone, through `DO_NOT_TRACK`, which aoe treats as
+    /// absolute: no sends, no install id, and no consent modal.
+    ForceOff,
+}
+
+/// Environment variable holding the deployment-level override.
+pub const TELEMETRY_POLICY_ENV: &str = "WORKSPACE_TELEMETRY_POLICY";
+
+/// The script [`TelemetryPolicy::wrap_command`] runs a force-on workspace
+/// through. A fixed constant with nothing interpolated into it, taking the real
+/// command through `"$0"` / `"$@"` so every argument stays a separate argv
+/// element and none of them is ever reparsed as shell source.
+///
+/// `&&`, not `;` or `|| true`: on an aoe too old for the subcommand the
+/// container must die rather than come up pretending the policy applied. `exec`
+/// so the shell is replaced and aoe remains the container's main process, with
+/// its signals and logs unchanged.
+const FORCE_ON_SCRIPT: &str = r#"aoe telemetry enable && exec "$0" "$@""#;
+
+impl TelemetryPolicy {
+    /// The stored / wire value. Also what a backend records as drift metadata,
+    /// so changing one of these strings would recreate every workspace once.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TelemetryPolicy::UserChoice => "user_choice",
+            TelemetryPolicy::ForceOn => "force_on",
+            TelemetryPolicy::ForceOff => "force_off",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<Self> {
+        match raw.trim() {
+            "user_choice" => Some(TelemetryPolicy::UserChoice),
+            "force_on" => Some(TelemetryPolicy::ForceOn),
+            "force_off" => Some(TelemetryPolicy::ForceOff),
+            _ => None,
+        }
+    }
+
+    /// A stored value, read leniently. An unrecognized string (a policy a newer
+    /// CityHall wrote, a hand-edited row) reads as `UserChoice`: of the three
+    /// this is the one that touches nothing, so a value nobody here understands
+    /// cannot silently start forcing a decision on every user.
+    pub fn from_stored(raw: &str) -> Self {
+        TelemetryPolicy::parse(raw).unwrap_or_else(|| {
+            tracing::warn!(
+                policy = %raw,
+                "unknown stored telemetry policy, treating it as user_choice"
+            );
+            TelemetryPolicy::UserChoice
+        })
+    }
+
+    /// Variables to inject into the workspace environment for this policy.
+    ///
+    /// Owned by CityHall, never by the user: the agent-credential catalog is a
+    /// closed allowlist, so a credential form cannot supply `DO_NOT_TRACK` and
+    /// escape a force-on policy that way.
+    pub fn env_pairs(self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            TelemetryPolicy::ForceOff => &[("DO_NOT_TRACK", "1")],
+            TelemetryPolicy::UserChoice | TelemetryPolicy::ForceOn => &[],
+        }
+    }
+
+    /// `command` as the container should actually run it.
+    ///
+    /// Only force-on rewrites anything, and it wraps rather than replaces, so
+    /// the image's own ENTRYPOINT still runs first (in the reference image that
+    /// is what relocates each agent's config onto the volume). Enforcing the
+    /// policy here rather than in the image means it also holds for an image
+    /// built before this feature, and for a third-party one; an image with no
+    /// shell fails loudly instead of ignoring the policy.
+    pub fn wrap_command(self, command: Vec<String>) -> Vec<String> {
+        if self != TelemetryPolicy::ForceOn {
+            return command;
+        }
+        let mut wrapped = vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            FORCE_ON_SCRIPT.to_string(),
+        ];
+        wrapped.extend(command);
+        wrapped
+    }
+}
+
+/// The deployment-level policy override, or `None` when unset.
+///
+/// `Err` names the offending value: [`from_env`] fails CityHall's startup on it
+/// rather than falling back, because a typo in a deployment that means to force
+/// telemetry off must not quietly become "let the user choose".
+pub fn telemetry_policy_override() -> Result<Option<TelemetryPolicy>, String> {
+    let raw = std::env::var(TELEMETRY_POLICY_ENV).unwrap_or_default();
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    TelemetryPolicy::parse(raw).map(Some).ok_or_else(|| {
+        format!(
+            "invalid {TELEMETRY_POLICY_ENV} '{raw}' (expected user_choice, force_on, or force_off)"
+        )
+    })
 }
 
 /// How a workspace reaches its own config bundle.
@@ -110,6 +233,9 @@ pub trait Orchestrator: Send + Sync {
 /// provisioning registry it reports slow artifact jobs through. Invalid
 /// values fail CityHall startup instead of surfacing on first workspace use.
 pub fn from_env() -> Result<(Arc<dyn Orchestrator>, Arc<ProvisioningRegistry>), String> {
+    // Validated here so an unusable telemetry override is a startup failure,
+    // not a surprise on the first workspace start.
+    telemetry_policy_override()?;
     let registry = Arc::new(ProvisioningRegistry::default());
     let backend = std::env::var("WORKSPACE_BACKEND").unwrap_or_else(|_| "docker".to_string());
     let orchestrator: Arc<dyn Orchestrator> = match backend.as_str() {
@@ -338,6 +464,71 @@ mod tests {
             allowed_host_from_origin("http://localhost:3001"),
             "localhost:3001"
         );
+    }
+
+    #[test]
+    fn telemetry_policy_round_trips_and_rejects_anything_else() {
+        for policy in [
+            TelemetryPolicy::UserChoice,
+            TelemetryPolicy::ForceOn,
+            TelemetryPolicy::ForceOff,
+        ] {
+            assert_eq!(TelemetryPolicy::parse(policy.as_str()), Some(policy));
+        }
+        // What `WORKSPACE_TELEMETRY_POLICY` rejects at startup, rather than
+        // reading as "let the user choose" and undoing a deployment's force-off.
+        for raw in ["on", "off", "user", "true", "forceon", ""] {
+            assert_eq!(TelemetryPolicy::parse(raw), None, "{raw}");
+        }
+    }
+
+    /// A stored value is read leniently in the one safe direction: a policy this
+    /// build does not know cannot start forcing anything on users.
+    #[test]
+    fn an_unknown_stored_policy_reads_as_user_choice() {
+        assert_eq!(
+            TelemetryPolicy::from_stored("force_maybe"),
+            TelemetryPolicy::UserChoice
+        );
+        assert_eq!(
+            TelemetryPolicy::from_stored("force_off"),
+            TelemetryPolicy::ForceOff
+        );
+    }
+
+    #[test]
+    fn only_force_off_injects_do_not_track() {
+        assert_eq!(
+            TelemetryPolicy::ForceOff.env_pairs(),
+            &[("DO_NOT_TRACK", "1")]
+        );
+        assert!(TelemetryPolicy::ForceOn.env_pairs().is_empty());
+        assert!(TelemetryPolicy::UserChoice.env_pairs().is_empty());
+    }
+
+    /// The force-on wrapper must leave every `aoe serve` argument its own argv
+    /// element (nothing is interpolated into the script, so nothing an operator
+    /// configures is ever reparsed as shell source), and must not touch the
+    /// command for the other two policies.
+    #[test]
+    fn force_on_wraps_the_command_without_rewriting_its_arguments() {
+        let command: Vec<String> = ["aoe", "serve", "--allowed-host", "ws.example.com"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let wrapped = TelemetryPolicy::ForceOn.wrap_command(command.clone());
+        assert_eq!(wrapped[..2], ["sh".to_string(), "-c".to_string()]);
+        assert!(
+            wrapped[2].contains("aoe telemetry enable &&") && wrapped[2].contains(r#"exec "$0""#),
+            "{}",
+            wrapped[2]
+        );
+        assert_eq!(wrapped[3..], command[..]);
+
+        for policy in [TelemetryPolicy::UserChoice, TelemetryPolicy::ForceOff] {
+            assert_eq!(policy.wrap_command(command.clone()), command);
+        }
     }
 
     #[test]

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -482,6 +482,64 @@ mod tests {
         }
     }
 
+    /// The two behaviors layered on top of `parse`, and what the rest of the
+    /// feature leans on: an unset or blank variable means "no override" so the
+    /// stored setting decides, and a bad value is an error naming itself so
+    /// `from_env` can refuse to start rather than quietly serving `user_choice`
+    /// to a deployment that meant to force telemetry off.
+    #[test]
+    fn the_telemetry_override_is_optional_and_strict() {
+        let _guard = TelemetryEnvGuard::acquire();
+
+        for unset in ["", "   "] {
+            std::env::set_var(TELEMETRY_POLICY_ENV, unset);
+            assert_eq!(telemetry_policy_override(), Ok(None), "{unset:?}");
+        }
+        std::env::remove_var(TELEMETRY_POLICY_ENV);
+        assert_eq!(telemetry_policy_override(), Ok(None));
+
+        std::env::set_var(TELEMETRY_POLICY_ENV, " force_off ");
+        assert_eq!(
+            telemetry_policy_override(),
+            Ok(Some(TelemetryPolicy::ForceOff))
+        );
+
+        std::env::set_var(TELEMETRY_POLICY_ENV, "off");
+        let err = telemetry_policy_override().unwrap_err();
+        assert!(err.contains("off"), "must name the value: {err}");
+        assert!(err.contains(TELEMETRY_POLICY_ENV), "{err}");
+    }
+
+    /// Serializes the tests that write `WORKSPACE_TELEMETRY_POLICY` and restores
+    /// what was there, the same shape as `crypto::guard_key_env`. Restoring on
+    /// drop rather than at the end of a test body, because a panic unwinds past
+    /// cleanup written after it and the next test would read the leftovers.
+    struct TelemetryEnvGuard {
+        #[allow(dead_code)]
+        lock: std::sync::MutexGuard<'static, ()>,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl TelemetryEnvGuard {
+        fn acquire() -> Self {
+            static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+            let lock = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            TelemetryEnvGuard {
+                lock,
+                previous: std::env::var_os(TELEMETRY_POLICY_ENV),
+            }
+        }
+    }
+
+    impl Drop for TelemetryEnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(TELEMETRY_POLICY_ENV, value),
+                None => std::env::remove_var(TELEMETRY_POLICY_ENV),
+            }
+        }
+    }
+
     /// A stored value is read leniently in the one safe direction: a policy this
     /// build does not know cannot start forcing anything on users.
     #[test]

--- a/api/src/orchestrator/process.rs
+++ b/api/src/orchestrator/process.rs
@@ -33,6 +33,10 @@ const START_ATTEMPTS: u32 = 2;
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
 /// Sanity cap on the release tarball size.
 const MAX_DOWNLOAD_BYTES: u64 = 1024 * 1024 * 1024;
+/// Budget for the `aoe telemetry enable` a force-on policy runs before the
+/// server starts. It only writes two small files, so anything near this means
+/// it is blocked rather than slow.
+const FORCE_ON_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct ProcessOrchestrator {
     root: PathBuf,
@@ -122,7 +126,7 @@ impl ProcessOrchestrator {
         std::fs::create_dir_all(&home).map_err(|e| {
             OrchestratorError::Runtime(format!("failed to create workspace home: {e}"))
         })?;
-        apply_force_on(spec, &binary, &home)?;
+        apply_force_on(spec, &binary, &home, FORCE_ON_TIMEOUT).await?;
 
         let mut last_err = None;
         for _ in 0..START_ATTEMPTS {
@@ -481,22 +485,37 @@ fn validate_version(version: &str) -> Result<(), OrchestratorError> {
 /// commands, so it can run one, check it, then run the other. A failure fails
 /// the start, naming the command, rather than leaving a workspace up under a
 /// policy that was not applied.
-fn apply_force_on(
+///
+/// Bounded, and run through tokio like every other CLI this crate shells out
+/// to. aoe takes a lock on the data dir it is about to write, so a concurrent
+/// aoe holding it makes this command wait; unbounded, that would hold a runtime
+/// worker and hang the workspace start with no explanation. `kill_on_drop`
+/// means the expired child is killed and reaped when the timeout drops it.
+async fn apply_force_on(
     spec: &WorkspaceSpec,
     binary: &Path,
     home: &Path,
+    timeout: Duration,
 ) -> Result<(), OrchestratorError> {
     if spec.telemetry != TelemetryPolicy::ForceOn {
         return Ok(());
     }
-    let output = std::process::Command::new(binary)
-        .args(["telemetry", "enable"])
+    let mut cmd = tokio::process::Command::new(binary);
+    cmd.args(["telemetry", "enable"])
         .env("HOME", home)
         // Removed for the same reason as in the spawn: an inherited
         // `DO_NOT_TRACK` would make aoe report the opt-in as suppressed.
         .env_remove("DO_NOT_TRACK")
         .current_dir(home)
-        .output()
+        .kill_on_drop(true);
+    let output = tokio::time::timeout(timeout, cmd.output())
+        .await
+        .map_err(|_| {
+            OrchestratorError::Runtime(format!(
+                "`aoe telemetry enable` did not finish within {timeout:?} while forcing \
+                 telemetry on; another aoe may be holding the workspace's config lock"
+            ))
+        })?
         .map_err(|e| {
             OrchestratorError::Runtime(format!("failed to run `aoe telemetry enable`: {e}"))
         })?;
@@ -542,22 +561,15 @@ mod tests {
     /// the admin set and CityHall did not apply. The other policies must not run
     /// the command at all, which is what makes them work with an aoe too old to
     /// have it.
-    #[test]
-    fn force_on_fails_the_start_when_aoe_cannot_apply_it() {
+    #[tokio::test]
+    async fn force_on_fails_the_start_when_aoe_cannot_apply_it() {
         let orch = scratch("telemetry");
         let home = orch.user_dir(1).join("home");
         std::fs::create_dir_all(&home).unwrap();
 
-        let fake = |name: &str, body: &str| {
-            let path = orch.root.join(name);
-            std::fs::write(&path, body).unwrap();
-            let mut perms = std::fs::metadata(&path).unwrap().permissions();
-            std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
-            std::fs::set_permissions(&path, perms).unwrap();
-            path
-        };
-        let works = fake("aoe-ok", "#!/bin/sh\nexit 0\n");
-        let broken = fake(
+        let works = fake_aoe(&orch, "aoe-ok", "#!/bin/sh\nexit 0\n");
+        let broken = fake_aoe(
+            &orch,
             "aoe-old",
             "#!/bin/sh\necho 'unknown subcommand' >&2\nexit 1\n",
         );
@@ -566,8 +578,11 @@ mod tests {
             telemetry: TelemetryPolicy::ForceOn,
             ..spec_for(1)
         };
-        assert!(apply_force_on(&spec, &works, &home).is_ok());
-        let err = apply_force_on(&spec, &broken, &home)
+        assert!(apply_force_on(&spec, &works, &home, FORCE_ON_TIMEOUT)
+            .await
+            .is_ok());
+        let err = apply_force_on(&spec, &broken, &home, FORCE_ON_TIMEOUT)
+            .await
             .unwrap_err()
             .to_string();
         assert!(err.contains("telemetry enable"), "{err}");
@@ -583,8 +598,48 @@ mod tests {
                 telemetry: policy,
                 ..spec_for(1)
             };
-            assert!(apply_force_on(&spec, &missing, &home).is_ok());
+            assert!(apply_force_on(&spec, &missing, &home, FORCE_ON_TIMEOUT)
+                .await
+                .is_ok());
         }
+    }
+
+    /// aoe locks the data dir it is about to write, so a concurrent aoe holding
+    /// that lock makes this command wait. Unbounded it would hold a runtime
+    /// worker and hang the start with nothing to read; the deadline turns that
+    /// into a start failure that says what is likely wrong.
+    #[tokio::test]
+    async fn a_hung_telemetry_enable_hits_the_deadline() {
+        let orch = scratch("telemetry-hang");
+        let home = orch.user_dir(1).join("home");
+        std::fs::create_dir_all(&home).unwrap();
+        let hangs = fake_aoe(&orch, "aoe-hangs", "#!/bin/sh\nsleep 30\n");
+
+        let spec = WorkspaceSpec {
+            telemetry: TelemetryPolicy::ForceOn,
+            ..spec_for(1)
+        };
+        let err = apply_force_on(&spec, &hangs, &home, Duration::from_millis(100))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("did not finish"), "{err}");
+        // `kill_on_drop` reaps the child when the expired timeout drops it, so
+        // no `sleep` is left behind holding the workspace's lock.
+        assert!(
+            err.contains("config lock"),
+            "must name the likely cause: {err}"
+        );
+    }
+
+    /// An executable stand-in for the aoe binary.
+    fn fake_aoe(orch: &ProcessOrchestrator, name: &str, body: &str) -> PathBuf {
+        let path = orch.root.join(name);
+        std::fs::write(&path, body).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+        path
     }
 
     fn spec_for(user_id: i32) -> WorkspaceSpec {

--- a/api/src/orchestrator/process.rs
+++ b/api/src/orchestrator/process.rs
@@ -21,7 +21,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     binary_key, http_probe, proxy_allowed_host, proxy_allowed_origin, wait_ready, Begin,
-    Orchestrator, OrchestratorError, ProvisioningRegistry, WorkspaceSpec, WorkspaceStatus,
+    Orchestrator, OrchestratorError, ProvisioningRegistry, TelemetryPolicy, WorkspaceSpec,
+    WorkspaceStatus,
 };
 
 /// Grace period between SIGTERM and SIGKILL on stop.
@@ -52,6 +53,13 @@ struct RunState {
     /// drift).
     #[serde(default)]
     env_fingerprint: String,
+    /// The telemetry policy this process was spawned under, so a policy change
+    /// is drift like a version or credential change is. `#[serde(default)]` for
+    /// the same reason as the fingerprint above: a state.json written before
+    /// the policy existed reads back as `user_choice`, which is what such a
+    /// process is in fact running under, so an upgrade alone restarts nothing.
+    #[serde(default)]
+    telemetry: String,
 }
 
 impl ProcessOrchestrator {
@@ -114,6 +122,7 @@ impl ProcessOrchestrator {
         std::fs::create_dir_all(&home).map_err(|e| {
             OrchestratorError::Runtime(format!("failed to create workspace home: {e}"))
         })?;
+        apply_force_on(spec, &binary, &home)?;
 
         let mut last_err = None;
         for _ in 0..START_ATTEMPTS {
@@ -127,6 +136,7 @@ impl ProcessOrchestrator {
                     port,
                     version: spec.version.clone(),
                     env_fingerprint: spec.agent_env.fingerprint.clone(),
+                    telemetry: spec.telemetry.as_str().to_string(),
                 },
             )?;
             match wait_ready(&addr).await {
@@ -177,6 +187,14 @@ impl ProcessOrchestrator {
         ])
         .env("HOME", home)
         .current_dir(home);
+        // The telemetry policy's variables. `DO_NOT_TRACK` is removed first,
+        // always: unlike a container, this process inherits CityHall's own
+        // environment, so a `DO_NOT_TRACK` set for CityHall itself would
+        // otherwise force every workspace off whatever the admin chose.
+        cmd.env_remove("DO_NOT_TRACK");
+        for (name, value) in spec.telemetry.env_pairs() {
+            cmd.env(name, value);
+        }
         // Where the workspace fetches its config bundle at boot.
         if let Some(bundle) = &spec.bundle {
             cmd.env("AOE_CITYHALL_BUNDLE_URL", &bundle.url)
@@ -275,19 +293,21 @@ impl Orchestrator for ProcessOrchestrator {
                 let addr = format!("127.0.0.1:{}", state.port);
                 if state.version == spec.version
                     && state.env_fingerprint == spec.agent_env.fingerprint
+                    && TelemetryPolicy::from_stored(&state.telemetry) == spec.telemetry
                     && http_probe(&addr).await
                 {
                     return Ok(addr);
                 }
-                // Version drift, a credential change, a hung process, or a
-                // recycled PID that is not our workspace: clear it and start
-                // fresh. A credential change must terminate and respawn
-                // because Command::env is only set once, at spawn.
+                // Version drift, a credential change, a telemetry policy
+                // change, a hung process, or a recycled PID that is not our
+                // workspace: clear it and start fresh. A credential or policy
+                // change must terminate and respawn because Command::env is
+                // only set once, at spawn.
                 tracing::info!(
                     user_id = spec.user_id,
                     from = %state.version,
                     to = %spec.version,
-                    "restarting workspace process for a version or credential change"
+                    "restarting workspace process for a version, credential, or telemetry policy change"
                 );
                 self.terminate(state.pid).await;
             }
@@ -452,6 +472,43 @@ fn validate_version(version: &str) -> Result<(), OrchestratorError> {
     }
 }
 
+/// Assert a force-on telemetry policy against this workspace's data, before its
+/// server starts, by running aoe's own `telemetry enable`. That is what both
+/// enables telemetry and records the consent as answered, so CityHall never has
+/// to touch aoe's config or state files itself.
+///
+/// No shell wrapper here, unlike the container backends: CityHall spawns both
+/// commands, so it can run one, check it, then run the other. A failure fails
+/// the start, naming the command, rather than leaving a workspace up under a
+/// policy that was not applied.
+fn apply_force_on(
+    spec: &WorkspaceSpec,
+    binary: &Path,
+    home: &Path,
+) -> Result<(), OrchestratorError> {
+    if spec.telemetry != TelemetryPolicy::ForceOn {
+        return Ok(());
+    }
+    let output = std::process::Command::new(binary)
+        .args(["telemetry", "enable"])
+        .env("HOME", home)
+        // Removed for the same reason as in the spawn: an inherited
+        // `DO_NOT_TRACK` would make aoe report the opt-in as suppressed.
+        .env_remove("DO_NOT_TRACK")
+        .current_dir(home)
+        .output()
+        .map_err(|e| {
+            OrchestratorError::Runtime(format!("failed to run `aoe telemetry enable`: {e}"))
+        })?;
+    if !output.status.success() {
+        return Err(OrchestratorError::Runtime(format!(
+            "`aoe telemetry enable` failed while forcing telemetry on: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
 fn alive(pid: i32) -> bool {
     // Signal 0 probes existence without touching the process.
     unsafe { libc::kill(pid, 0) == 0 }
@@ -479,6 +536,67 @@ fn free_port() -> Result<u16, OrchestratorError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Force-on is asserted by aoe's own CLI, and a failure has to fail the
+    /// start: a workspace that came up anyway would be serving under a policy
+    /// the admin set and CityHall did not apply. The other policies must not run
+    /// the command at all, which is what makes them work with an aoe too old to
+    /// have it.
+    #[test]
+    fn force_on_fails_the_start_when_aoe_cannot_apply_it() {
+        let orch = scratch("telemetry");
+        let home = orch.user_dir(1).join("home");
+        std::fs::create_dir_all(&home).unwrap();
+
+        let fake = |name: &str, body: &str| {
+            let path = orch.root.join(name);
+            std::fs::write(&path, body).unwrap();
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+            path
+        };
+        let works = fake("aoe-ok", "#!/bin/sh\nexit 0\n");
+        let broken = fake(
+            "aoe-old",
+            "#!/bin/sh\necho 'unknown subcommand' >&2\nexit 1\n",
+        );
+
+        let spec = WorkspaceSpec {
+            telemetry: TelemetryPolicy::ForceOn,
+            ..spec_for(1)
+        };
+        assert!(apply_force_on(&spec, &works, &home).is_ok());
+        let err = apply_force_on(&spec, &broken, &home)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("telemetry enable"), "{err}");
+        assert!(
+            err.contains("unknown subcommand"),
+            "must carry aoe's own stderr: {err}"
+        );
+
+        // Nothing is run for the other two, so a missing binary is fine.
+        let missing = orch.root.join("does-not-exist");
+        for policy in [TelemetryPolicy::UserChoice, TelemetryPolicy::ForceOff] {
+            let spec = WorkspaceSpec {
+                telemetry: policy,
+                ..spec_for(1)
+            };
+            assert!(apply_force_on(&spec, &missing, &home).is_ok());
+        }
+    }
+
+    fn spec_for(user_id: i32) -> WorkspaceSpec {
+        WorkspaceSpec {
+            user_id,
+            image: "unused".to_string(),
+            version: "v1.0.0".to_string(),
+            bundle: None,
+            agent_env: crate::agent_credentials::AgentEnv::default(),
+            telemetry: TelemetryPolicy::default(),
+        }
+    }
 
     fn scratch(name: &str) -> ProcessOrchestrator {
         let root = std::env::temp_dir().join(format!(
@@ -515,6 +633,7 @@ mod tests {
                 port: 43210,
                 version: "v1.0.0".to_string(),
                 env_fingerprint: "somefingerprint".to_string(),
+                telemetry: TelemetryPolicy::default().as_str().to_string(),
             },
         )
         .unwrap();
@@ -562,6 +681,7 @@ mod tests {
                 port: 1,
                 version: "v1".to_string(),
                 env_fingerprint: String::new(),
+                telemetry: TelemetryPolicy::default().as_str().to_string(),
             },
         )
         .unwrap();
@@ -576,6 +696,7 @@ mod tests {
                 port: 45678,
                 version: "v1".to_string(),
                 env_fingerprint: String::new(),
+                telemetry: TelemetryPolicy::default().as_str().to_string(),
             },
         )
         .unwrap();
@@ -596,6 +717,7 @@ mod tests {
             version: "v9.9.9".to_string(),
             bundle: None,
             agent_env: crate::agent_credentials::AgentEnv::default(),
+            telemetry: TelemetryPolicy::default(),
         };
         // A recent failed download attempt is surfaced as guidance instead of
         // re-spawning a download on every request.

--- a/api/src/workspaces.rs
+++ b/api/src/workspaces.rs
@@ -10,7 +10,8 @@ use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, Qu
 use crate::entities::{workspace, workspace_settings};
 use crate::error::AppError;
 use crate::orchestrator::{
-    bundle_url, render_image, BundleAccess, OrchestratorError, WorkspaceSpec, WorkspaceStatus,
+    bundle_url, render_image, telemetry_policy_override, BundleAccess, OrchestratorError,
+    TelemetryPolicy, WorkspaceSpec, WorkspaceStatus,
 };
 use crate::state::AppState;
 
@@ -27,8 +28,23 @@ pub async fn settings(db: &DatabaseConnection) -> Result<workspace_settings::Mod
             image_template: "cityhall/aoe:{version}".to_string(),
             default_version: None,
             idle_stop_minutes: 30,
+            telemetry_policy: TelemetryPolicy::default().as_str().to_string(),
             updated_at: Utc::now(),
         }))
+}
+
+/// The telemetry policy workspaces actually run under: the deployment-level
+/// override when one is set, otherwise the stored setting.
+///
+/// The override's own validity was settled at startup (see
+/// [`crate::orchestrator::from_env`]), so an `Err` here cannot happen; reading
+/// it as "no override" if it somehow did would be the same lenient direction as
+/// [`TelemetryPolicy::from_stored`].
+pub fn effective_telemetry_policy(settings: &workspace_settings::Model) -> TelemetryPolicy {
+    telemetry_policy_override()
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| TelemetryPolicy::from_stored(&settings.telemetry_policy))
 }
 
 /// On a first startup (no settings row saved yet), pre-fill the default
@@ -67,6 +83,7 @@ async fn apply_seeded_version(db: &DatabaseConnection, version: String) -> Resul
         image_template: Set(defaults.image_template),
         default_version: Set(Some(version)),
         idle_stop_minutes: Set(defaults.idle_stop_minutes),
+        telemetry_policy: Set(defaults.telemetry_policy),
         updated_at: Set(Utc::now()),
     }
     .insert(db)
@@ -280,6 +297,7 @@ pub fn build_spec(
         version,
         bundle,
         agent_env: crate::agent_credentials::AgentEnv::default(),
+        telemetry: effective_telemetry_policy(settings),
     })
 }
 
@@ -510,6 +528,7 @@ mod tests {
             image_template: "cityhall/aoe:{version}".to_string(),
             default_version: default_version.map(String::from),
             idle_stop_minutes: 30,
+            telemetry_policy: TelemetryPolicy::default().as_str().to_string(),
             updated_at: Utc::now(),
         }
     }
@@ -534,6 +553,7 @@ mod tests {
             image_template: Set("cityhall/aoe:{version}".to_string()),
             default_version: Set(None),
             idle_stop_minutes: Set(30),
+            telemetry_policy: Set(TelemetryPolicy::default().as_str().to_string()),
             updated_at: Set(Utc::now()),
         }
         .insert(&db)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ Docker, Compose, or Kubernetes deployment without a config file.
 | `CONTAINER_CLI` | `docker`                         | Container CLI used by the docker backend (e.g. `podman`). |
 | `WORKSPACE_DOCKER_NETWORK` | _(unset)_             | Docker network workspaces join (no published ports); for CityHall-in-compose. |
 | `WORKSPACE_BUNDLE_ORIGIN` | _(unset)_              | Origin a *workspace* uses to reach CityHall, for fetching its config bundle (see [Workspaces](workspaces.md#workspace-configuration)). Unset means workspaces start unconfigured. |
+| `WORKSPACE_TELEMETRY_POLICY` | _(the stored setting)_ | Pins aoe telemetry for every workspace: `user_choice`, `force_on`, or `force_off` (see [Workspaces](workspaces.md#telemetry)). Any other value fails startup. |
 | `WORKSPACE_K8S_NAMESPACE` | _(pod namespace)_      | Namespace workspace objects are created in. |
 | `WORKSPACE_K8S_VOLUME_SIZE` | `5Gi`                | PVC size per workspace. |
 | `WORKSPACE_K8S_STORAGE_CLASS` | _(cluster default)_ | Storage class for workspace PVCs. |

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -410,10 +410,14 @@ What each state does to a workspace:
   Works with any workspace image.
 - **On for everyone** runs `aoe telemetry enable` in the workspace before the
   server starts, which is what also records the consent as answered, so no prompt
-  appears. It needs an image with a shell and an aoe new enough to have that
-  subcommand; on an image without either, the workspace fails to start rather
-  than coming up with the policy unapplied, and the reason is in the container
-  log (`docker logs cityhall-workspace-u<id>`).
+  appears. On the container backends it needs an image with a shell and an aoe new
+  enough to have that subcommand; without either, the workspace fails to start
+  rather than coming up with the policy unapplied. The reason is in that
+  workspace's own backend log: `docker logs cityhall-workspace-u<id>` on the
+  docker backend, `kubectl logs deploy/cityhall-workspace-u<id>` on kubernetes,
+  and `$WORKSPACE_PROCESS_DIR/u<id>/serve.log` on the process backend (which runs
+  the command directly, needing no shell, and reports the failure through the
+  API instead).
 - **Let each user choose** injects nothing. aoe's own prompt reaches the user and
   CityHall never marks the consent as answered on their behalf.
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -391,6 +391,44 @@ are readable through `/proc/<pid>/environ` by the CityHall OS user, which is the
 same user every workspace runs as. In every case, anyone who can administer the
 runtime can read a workspace's credentials.
 
+## Telemetry
+
+aoe's usage telemetry is opt-in, and aoe asks each user for that opt-in inside
+their own workspace. In a CityHall deployment that is the wrong person to ask, so
+**Settings → Workspaces → aoe telemetry** decides it for everyone: off for
+everyone, on for everyone, or let each user choose (the default, and how it
+behaved before this setting existed).
+
+`WORKSPACE_TELEMETRY_POLICY` (`user_choice`, `force_on`, `force_off`) pins the
+policy for the whole deployment. While it is set it wins, and a choice saved on
+the page is stored for when the variable is removed rather than applied.
+
+What each state does to a workspace:
+
+- **Off for everyone** sets `DO_NOT_TRACK=1`, which aoe treats as absolute:
+  nothing is sent, no install id is generated, and no consent prompt appears.
+  Works with any workspace image.
+- **On for everyone** runs `aoe telemetry enable` in the workspace before the
+  server starts, which is what also records the consent as answered, so no prompt
+  appears. It needs an image with a shell and an aoe new enough to have that
+  subcommand; on an image without either, the workspace fails to start rather
+  than coming up with the policy unapplied, and the reason is in the container
+  log (`docker logs cityhall-workspace-u<id>`).
+- **Let each user choose** injects nothing. aoe's own prompt reaches the user and
+  CityHall never marks the consent as answered on their behalf.
+
+A change reaches a workspace the next time it starts, which for a stopped one is
+automatic. Tick **restart running workspaces on save** to apply it to running
+ones immediately; that recreates their containers, ending whatever their users
+are running, which is why it is not the default.
+
+Two things worth knowing before forcing telemetry on. Suppressing the consent
+prompt makes disclosing the collection to your users your deployment's
+responsibility, not aoe's. And the opt-in is recorded in each user's data volume,
+so relaxing the policy back to "let each user choose" stops CityHall enforcing
+anything but leaves those users opted in until they turn it off themselves;
+CityHall does not rewrite aoe's stored consent to undo it.
+
 ## The workspace proxy
 
 Workspaces are served through a dedicated listener (default

--- a/web/src/components/WorkspaceSettings.test.ts
+++ b/web/src/components/WorkspaceSettings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { telemetryOverrideNote } from "./WorkspaceSettings";
+import { effectiveTelemetryPolicy, telemetryOverrideNote } from "./WorkspaceSettings";
 
 // There is no @testing-library/react in this repo, so this covers the one
 // non-obvious predicate behind the settings form: an environment-pinned policy
@@ -17,5 +17,20 @@ describe("telemetryOverrideNote", () => {
 
   it("says a save is stored rather than applied while pinned", () => {
     expect(telemetryOverrideNote("force_on")).toContain("does not apply while it is set");
+  });
+});
+
+// What gates the force-on disclosure. Reading the selected policy alone would
+// hide it when the environment forces telemetry on, and show it falsely when the
+// environment forces it off over a stored force-on.
+describe("effectiveTelemetryPolicy", () => {
+  it("is the selected policy when nothing is pinned", () => {
+    expect(effectiveTelemetryPolicy("force_on", null)).toBe("force_on");
+    expect(effectiveTelemetryPolicy("user_choice", null)).toBe("user_choice");
+  });
+
+  it("lets the override win", () => {
+    expect(effectiveTelemetryPolicy("user_choice", "force_on")).toBe("force_on");
+    expect(effectiveTelemetryPolicy("force_on", "force_off")).toBe("force_off");
   });
 });

--- a/web/src/components/WorkspaceSettings.test.ts
+++ b/web/src/components/WorkspaceSettings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { effectiveTelemetryPolicy, telemetryOverrideNote } from "./WorkspaceSettings";
+import { effectiveTelemetryPolicy, isKnownTelemetryPolicy, telemetryOverrideNote } from "./WorkspaceSettings";
 
 // There is no @testing-library/react in this repo, so this covers the one
 // non-obvious predicate behind the settings form: an environment-pinned policy
@@ -32,5 +32,13 @@ describe("effectiveTelemetryPolicy", () => {
   it("lets the override win", () => {
     expect(effectiveTelemetryPolicy("user_choice", "force_on")).toBe("force_on");
     expect(effectiveTelemetryPolicy("force_on", "force_off")).toBe("force_off");
+  });
+
+  // A policy stored by a newer CityHall round-trips through the form untouched,
+  // but this build enforces nothing for it, exactly as the server reads it.
+  it("treats a policy it does not know as user_choice", () => {
+    expect(effectiveTelemetryPolicy("force_maybe", null)).toBe("user_choice");
+    expect(isKnownTelemetryPolicy("force_maybe")).toBe(false);
+    expect(isKnownTelemetryPolicy("force_off")).toBe(true);
   });
 });

--- a/web/src/components/WorkspaceSettings.test.ts
+++ b/web/src/components/WorkspaceSettings.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { telemetryOverrideNote } from "./WorkspaceSettings";
+
+// There is no @testing-library/react in this repo, so this covers the one
+// non-obvious predicate behind the settings form: an environment-pinned policy
+// has to be announced, and it must not read as "your save took effect".
+describe("telemetryOverrideNote", () => {
+  it("says nothing when no override is set", () => {
+    expect(telemetryOverrideNote(null)).toBeNull();
+  });
+
+  it("names the variable and the policy it pins", () => {
+    const note = telemetryOverrideNote("force_off");
+    expect(note).toContain("WORKSPACE_TELEMETRY_POLICY");
+    expect(note).toContain("Off for everyone");
+  });
+
+  it("says a save is stored rather than applied while pinned", () => {
+    expect(telemetryOverrideNote("force_on")).toContain("does not apply while it is set");
+  });
+});

--- a/web/src/components/WorkspaceSettings.tsx
+++ b/web/src/components/WorkspaceSettings.tsx
@@ -18,6 +18,10 @@ export function telemetryOverrideNote(override: TelemetryPolicy | null): string 
   return `Pinned to "${TELEMETRY_LABELS[override]}" by WORKSPACE_TELEMETRY_POLICY in this deployment's environment. A saved choice is stored for when that variable is removed, and does not apply while it is set.`;
 }
 
+export function isKnownTelemetryPolicy(value: string): value is TelemetryPolicy {
+  return value in TELEMETRY_LABELS;
+}
+
 /// The policy workspaces would run under: the environment override when there is
 /// one, otherwise whatever is currently selected.
 ///
@@ -25,8 +29,13 @@ export function telemetryOverrideNote(override: TelemetryPolicy | null): string 
 /// choosing it rather than only after the fact. The server computes the same
 /// thing from the stored value; reading its answer here instead would be a
 /// save behind whatever the form shows.
-export function effectiveTelemetryPolicy(selected: TelemetryPolicy, override: TelemetryPolicy | null): TelemetryPolicy {
-  return override ?? selected;
+///
+/// A selection this build does not know is a policy written by a newer CityHall,
+/// which the server also reads as `user_choice`, so neither forced-state notice
+/// claims something that is not being enforced here.
+export function effectiveTelemetryPolicy(selected: string, override: TelemetryPolicy | null): TelemetryPolicy {
+  if (override) return override;
+  return isKnownTelemetryPolicy(selected) ? selected : "user_choice";
 }
 
 export function WorkspaceSettingsSection() {
@@ -35,7 +44,9 @@ export function WorkspaceSettingsSection() {
   const [imageTemplate, setImageTemplate] = useState("");
   const [defaultVersion, setDefaultVersion] = useState("");
   const [idleStopMinutes, setIdleStopMinutes] = useState(30);
-  const [telemetryPolicy, setTelemetryPolicy] = useState<TelemetryPolicy>("user_choice");
+  // A plain string, not a TelemetryPolicy: a policy stored by a newer CityHall
+  // has to round-trip through this form untouched.
+  const [telemetryPolicy, setTelemetryPolicy] = useState<string>("user_choice");
   const [telemetryOverride, setTelemetryOverride] = useState<TelemetryPolicy | null>(null);
   const [restartRunning, setRestartRunning] = useState(false);
   const [versions, setVersions] = useState<string[]>([]);
@@ -133,7 +144,13 @@ export function WorkspaceSettingsSection() {
             />
           </Field>
           <Field label="aoe telemetry">
-            <Select value={telemetryPolicy} onChange={(e) => setTelemetryPolicy(e.target.value as TelemetryPolicy)}>
+            <Select value={telemetryPolicy} onChange={(e) => setTelemetryPolicy(e.target.value)}>
+              {/* Keeps an unrecognized stored policy selectable, so leaving the
+                  control alone saves it back verbatim instead of the browser
+                  silently falling back to the first option. */}
+              {!isKnownTelemetryPolicy(telemetryPolicy) && (
+                <option value={telemetryPolicy}>Set by a newer CityHall ({telemetryPolicy})</option>
+              )}
               {(Object.keys(TELEMETRY_LABELS) as TelemetryPolicy[]).map((policy) => (
                 <option key={policy} value={policy}>
                   {TELEMETRY_LABELS[policy]}

--- a/web/src/components/WorkspaceSettings.tsx
+++ b/web/src/components/WorkspaceSettings.tsx
@@ -18,6 +18,17 @@ export function telemetryOverrideNote(override: TelemetryPolicy | null): string 
   return `Pinned to "${TELEMETRY_LABELS[override]}" by WORKSPACE_TELEMETRY_POLICY in this deployment's environment. A saved choice is stored for when that variable is removed, and does not apply while it is set.`;
 }
 
+/// The policy workspaces would run under: the environment override when there is
+/// one, otherwise whatever is currently selected.
+///
+/// Selected, not saved, so the force-on disclosure appears while the admin is
+/// choosing it rather than only after the fact. The server computes the same
+/// thing from the stored value; reading its answer here instead would be a
+/// save behind whatever the form shows.
+export function effectiveTelemetryPolicy(selected: TelemetryPolicy, override: TelemetryPolicy | null): TelemetryPolicy {
+  return override ?? selected;
+}
+
 export function WorkspaceSettingsSection() {
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -134,7 +145,7 @@ export function WorkspaceSettingsSection() {
 
         {telemetryOverride && <p className="text-sm text-status-waiting">{telemetryOverrideNote(telemetryOverride)}</p>}
 
-        {telemetryPolicy === "force_on" && (
+        {effectiveTelemetryPolicy(telemetryPolicy, telemetryOverride) === "force_on" && (
           <p className="text-sm text-status-waiting">
             Turning telemetry on for everyone suppresses aoe's consent prompt and records the choice as answered in each
             user's workspace, so disclosing the collection to your users is your deployment's responsibility. Reverting

--- a/web/src/components/WorkspaceSettings.tsx
+++ b/web/src/components/WorkspaceSettings.tsx
@@ -1,8 +1,22 @@
 import { useCallback, useEffect, useState } from "react";
-import { api, ApiError, type WorkspaceSettings } from "../lib/api";
+import { api, ApiError, type TelemetryPolicy, type WorkspaceSettings } from "../lib/api";
 import { isOlderVersion } from "../lib/versions";
-import { Button, ErrorText, Field, Input } from "./ui";
+import { Button, ErrorText, Field, Input, Select } from "./ui";
 import { VersionField } from "./VersionField";
+
+const TELEMETRY_LABELS: Record<TelemetryPolicy, string> = {
+  user_choice: "Let each user choose",
+  force_on: "On for everyone",
+  force_off: "Off for everyone",
+};
+
+/// What to say when `WORKSPACE_TELEMETRY_POLICY` pins the policy, or null when
+/// nothing is pinned. The stored value is still saveable while pinned, so the
+/// note has to say that the choice is kept rather than applied.
+export function telemetryOverrideNote(override: TelemetryPolicy | null): string | null {
+  if (!override) return null;
+  return `Pinned to "${TELEMETRY_LABELS[override]}" by WORKSPACE_TELEMETRY_POLICY in this deployment's environment. A saved choice is stored for when that variable is removed, and does not apply while it is set.`;
+}
 
 export function WorkspaceSettingsSection() {
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -10,6 +24,9 @@ export function WorkspaceSettingsSection() {
   const [imageTemplate, setImageTemplate] = useState("");
   const [defaultVersion, setDefaultVersion] = useState("");
   const [idleStopMinutes, setIdleStopMinutes] = useState(30);
+  const [telemetryPolicy, setTelemetryPolicy] = useState<TelemetryPolicy>("user_choice");
+  const [telemetryOverride, setTelemetryOverride] = useState<TelemetryPolicy | null>(null);
+  const [restartRunning, setRestartRunning] = useState(false);
   const [versions, setVersions] = useState<string[]>([]);
   const [latest, setLatest] = useState<string | null>(null);
 
@@ -21,6 +38,8 @@ export function WorkspaceSettingsSection() {
     setImageTemplate(s.image_template);
     setDefaultVersion(s.default_version ?? "");
     setIdleStopMinutes(s.idle_stop_minutes);
+    setTelemetryPolicy(s.telemetry_policy);
+    setTelemetryOverride(s.telemetry_policy_override);
   }, []);
 
   const load = useCallback(async () => {
@@ -54,6 +73,8 @@ export function WorkspaceSettingsSection() {
           image_template: imageTemplate,
           default_version: defaultVersion.trim() || null,
           idle_stop_minutes: idleStopMinutes,
+          telemetry_policy: telemetryPolicy,
+          restart_running: restartRunning,
         }),
       );
       setSaved(true);
@@ -100,7 +121,41 @@ export function WorkspaceSettingsSection() {
               min={1}
             />
           </Field>
+          <Field label="aoe telemetry">
+            <Select value={telemetryPolicy} onChange={(e) => setTelemetryPolicy(e.target.value as TelemetryPolicy)}>
+              {(Object.keys(TELEMETRY_LABELS) as TelemetryPolicy[]).map((policy) => (
+                <option key={policy} value={policy}>
+                  {TELEMETRY_LABELS[policy]}
+                </option>
+              ))}
+            </Select>
+          </Field>
         </div>
+
+        {telemetryOverride && <p className="text-sm text-status-waiting">{telemetryOverrideNote(telemetryOverride)}</p>}
+
+        {telemetryPolicy === "force_on" && (
+          <p className="text-sm text-status-waiting">
+            Turning telemetry on for everyone suppresses aoe's consent prompt and records the choice as answered in each
+            user's workspace, so disclosing the collection to your users is your deployment's responsibility. Reverting
+            to "Let each user choose" stops enforcing it, but leaves those users opted in until they change it
+            themselves.
+          </p>
+        )}
+
+        <p className="text-sm text-text-secondary">
+          A telemetry change reaches a workspace the next time it starts.{" "}
+          <label className="inline-flex items-center gap-1.5">
+            <input
+              type="checkbox"
+              checked={restartRunning}
+              onChange={(e) => setRestartRunning(e.target.checked)}
+              className="h-4 w-4 accent-brand-500"
+            />
+            restart running workspaces on save
+          </label>{" "}
+          to apply it now, ending whatever their users are running.
+        </p>
 
         <p className="text-sm text-text-secondary">
           The image for a user is the template with <code className="text-text-primary">{"{version}"}</code> replaced by

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -124,15 +124,20 @@ export interface MyWorkspace {
   proxy_origin: string;
 }
 
-/// Who decides whether a workspace sends aoe telemetry.
+/// Who decides whether a workspace sends aoe telemetry. The three values this
+/// CityHall knows and can select; a stored policy is a plain string because a
+/// newer CityHall may have written one that is none of these.
 export type TelemetryPolicy = "user_choice" | "force_on" | "force_off";
 
 export interface WorkspaceSettings {
   image_template: string;
   default_version: string | null;
   idle_stop_minutes: number;
-  /// The stored policy, which is what a save writes.
-  telemetry_policy: TelemetryPolicy;
+  /// The stored policy, verbatim. Usually a `TelemetryPolicy`, but an opaque
+  /// value written by a newer CityHall is returned as-is so a save can echo it
+  /// back rather than flattening it; `effective_telemetry_policy` is where such
+  /// a value reads as `user_choice`.
+  telemetry_policy: string;
   /// Set when WORKSPACE_TELEMETRY_POLICY pins the policy for the deployment, in
   /// which case it wins over the stored one.
   telemetry_policy_override: TelemetryPolicy | null;
@@ -146,7 +151,9 @@ export interface WorkspaceSettingsUpdate {
   image_template: string;
   default_version: string | null;
   idle_stop_minutes: number;
-  telemetry_policy: TelemetryPolicy;
+  /// A `TelemetryPolicy`, or the stored value echoed back unchanged to keep an
+  /// opaque one. The server rejects any other string.
+  telemetry_policy: string;
   /// Recreate every running workspace so a saved policy applies now, which ends
   /// whatever their users are running. Stopped workspaces never need it.
   restart_running: boolean;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -124,10 +124,32 @@ export interface MyWorkspace {
   proxy_origin: string;
 }
 
+/// Who decides whether a workspace sends aoe telemetry.
+export type TelemetryPolicy = "user_choice" | "force_on" | "force_off";
+
 export interface WorkspaceSettings {
   image_template: string;
   default_version: string | null;
   idle_stop_minutes: number;
+  /// The stored policy, which is what a save writes.
+  telemetry_policy: TelemetryPolicy;
+  /// Set when WORKSPACE_TELEMETRY_POLICY pins the policy for the deployment, in
+  /// which case it wins over the stored one.
+  telemetry_policy_override: TelemetryPolicy | null;
+  /// What workspaces actually run under: the override, or the stored policy.
+  effective_telemetry_policy: TelemetryPolicy;
+}
+
+/// What a save sends: the settings an admin owns, without the two fields the
+/// server derives.
+export interface WorkspaceSettingsUpdate {
+  image_template: string;
+  default_version: string | null;
+  idle_stop_minutes: number;
+  telemetry_policy: TelemetryPolicy;
+  /// Recreate every running workspace so a saved policy applies now, which ends
+  /// whatever their users are running. Stopped workspaces never need it.
+  restart_running: boolean;
 }
 
 /// The aoe config bundle every workspace is provisioned with. Opaque TOML:
@@ -311,7 +333,7 @@ export const api = {
   workspaceAccessUrl: (userId: number) =>
     request<{ url: string }>(`/workspaces/${userId}/access-url`, { method: "POST" }),
   getWorkspaceSettings: () => request<WorkspaceSettings>("/settings/workspaces"),
-  updateWorkspaceSettings: (patch: WorkspaceSettings) =>
+  updateWorkspaceSettings: (patch: WorkspaceSettingsUpdate) =>
     request<WorkspaceSettings>("/settings/workspaces", {
       method: "PUT",
       body: JSON.stringify(patch),


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

aoe stores telemetry consent per user, inside that user's workspace volume (`config.toml: [telemetry] enabled`, `state.toml: has_responded_to_telemetry`). In a CityHall deployment that asks the wrong person: the decision belongs to the operator, and aoe's consent modal is exactly the kind of prompt CityHall client mode exists to remove. This adds one workspace setting with three states, force on, force off, or let each user choose, plus a `WORKSPACE_TELEMETRY_POLICY` override that pins it for the whole deployment.

Neither forced state needs an aoe-side change. **Force off** injects `DO_NOT_TRACK=1`, which aoe treats as absolute: nothing is sent, no install id is generated, and the modal is suppressed. **Force on** runs aoe's own `aoe telemetry enable` against the workspace data before the server starts, which is what both enables telemetry and records the consent as answered, so CityHall never touches aoe's config or state file formats itself. The config bundle could not carry this: `telemetry` is not in aoe's settings schema and its `validate_patch` rejects an unknown section outright.

The container backends apply force-on by wrapping the command they already pass as container args: `sh -c 'aoe telemetry enable && exec "$0" "$@"' aoe serve …`. The script is a fixed constant and the real command is forwarded through `"$0"` / `"$@"`, so every argument stays its own argv element and nothing an operator configures is reparsed as shell source; `exec` leaves aoe as the container's main process. Wrapping rather than replacing keeps the image's ENTRYPOINT in charge (in the reference image that is what puts each agent's config on the volume), and doing it here rather than in the image means an image built before this change is covered too. `&&` rather than `|| true`: on an image without a shell or with an aoe too old for the subcommand, the workspace fails to start instead of coming up under a policy that was not applied. The process backend needs no shell, it runs one command then the other, and it also clears an inherited `DO_NOT_TRACK` so CityHall's own environment cannot silently force every workspace off.

The policy is its own drift signal (docker label, kube pod-template annotation, process state field) rather than folded into the agent-credential fingerprint. That is load-bearing, not tidiness: a stopped container is otherwise resumed with `docker start` and its old environment, so a policy change would never reach it. Absent metadata reads as `user_choice`, and the kube annotation is written only when a policy is forced, so deploying this recreates and rolls nothing by itself. A change reaches a running workspace on its next start, with an opt-in "restart running workspaces on save" checkbox mirroring the version rollout's, because a recreate ends whatever the user is running.

Two deliberate non-goals. CityHall does not rewrite aoe's stored consent, so relaxing force-on back to "let each user choose" stops enforcing but leaves those users opted in; the admin page and the docs say so rather than quietly repairing a file CityHall does not own. And the end-user-facing disclosure notice is not here: an end user sees aoe's dashboard through the proxy, so that banner belongs upstream in aoe. The admin page carries the warning that disclosure is the operator's responsibility.

Also verified against the real workspace image rather than in tests alone: the wrapper leaves `enabled = true` plus `has_responded_to_telemetry = true` in the volume (so aoe's modal gate cannot fire), and `DO_NOT_TRACK=1` reports as `suppressed by DO_NOT_TRACK` even with `enabled = true` in the config.

Closes #40

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Leave the policy at **Let each user choose**, open a fresh user's workspace, and confirm aoe still shows its telemetry consent prompt (nothing is answered on their behalf).
- [ ] Set **Settings → Workspaces → aoe telemetry** to **Off for everyone**, save, restart that workspace, and confirm no prompt appears and `GET /api/telemetry/status` through the workspace reports `do_not_track: true`.
- [ ] Set it to **On for everyone**, save, restart, and confirm no prompt appears and the workspace reports `enabled: true, responded: true`.
- [ ] Save a policy change without ticking the restart box, confirm a running workspace is untouched, then stop it and start it again and confirm it comes back on the new policy (this is the stopped-container path that the old environment would otherwise survive).
- [ ] Save with **restart running workspaces on save** ticked and confirm running workspaces are recreated onto the new policy.
- [ ] Start CityHall with `WORKSPACE_TELEMETRY_POLICY=force_off` and confirm the settings page says the policy is pinned by the environment, that saving a different value stores it without changing what workspaces run under, and that removing the variable then applies the stored value.
- [ ] Start CityHall with `WORKSPACE_TELEMETRY_POLICY=nonsense` and confirm it refuses to start rather than falling back to "let each user choose".
- [ ] Pin a workspace to an aoe old enough to lack `aoe telemetry enable`, force telemetry on, and confirm the start fails rather than the workspace coming up with telemetry off.

## Checklist

- [x] New and existing tests pass
- [x] `cargo fmt` / `cargo clippy` clean (API changes)
- [x] `npm run lint` / `npm run format:check` clean (web changes)
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, the `/aoe-implement` skill)

Investigation, plan, and implementation drafted by Claude under my direction, with the force-on mechanism and the drift design pressure-tested through a two-model design debate before any code was written. I made the design calls, reviewed each commit, and run the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace telemetry controls with user-choice, forced-on, and forced-off options.
  * Deployment-level policies can override saved workspace settings.
  * Workspace settings show stored, enforced, and effective telemetry policies.
  * Optionally restart running workspaces when applying policy changes.
* **Documentation**
  * Documented telemetry policy configuration and environment overrides.
* **Bug Fixes**
  * Ensured telemetry settings are applied consistently across workspace launches and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->