### PR TITLE
feat(workspaces): let an admin choose the coding agents a workspace arrives with

### DIFF
--- a/api/src/agent_credentials.rs
+++ b/api/src/agent_credentials.rs
@@ -237,6 +237,9 @@ mod tests {
         assert!(lookup("LD_PRELOAD").is_none());
         assert!(lookup("HOME").is_none());
         assert!(lookup("AOE_CITYHALL_BUNDLE_TOKEN").is_none());
+        // Storable would mean a user could choose what their own workspace
+        // installs at boot, which is the operator's setting, not theirs.
+        assert!(lookup(crate::agents::ENV_VAR).is_none());
         // Case-sensitive, so a lowercase spelling is not a way in.
         assert!(lookup("anthropic_api_key").is_none());
     }

--- a/api/src/agents.rs
+++ b/api/src/agents.rs
@@ -1,0 +1,167 @@
+//! The coding agents an admin can have a workspace arrive with (#57).
+//!
+//! An operator picks a set here, CityHall hands the names to the workspace, and
+//! the reference image's entrypoint installs any that are missing. The catalog
+//! is closed for the same reason the credential catalog is: the value ends up in
+//! a workspace's environment, and the entrypoint turns each name into an install
+//! command, so a free-form list would be a way to run something of the
+//! operator's choosing inside every workspace. Names are all this side sends;
+//! the name-to-command map lives in the entrypoint, where an unrecognised name
+//! matches no branch and is skipped.
+//!
+//! **The installed set is a default, not a restriction.** aoe applies no
+//! allowlist to agent selection, and a terminal session can run any binary on
+//! `PATH` regardless of what was installed here. Enforcement needs
+//! agent-of-empires/agent-of-empires#3241.
+
+use crate::error::AppError;
+
+/// One agent an operator can ask for.
+pub struct WorkspaceAgent {
+    /// aoe's own name for the agent, which is also what the entrypoint's
+    /// install map is keyed on.
+    pub name: &'static str,
+    pub label: &'static str,
+}
+
+/// Every agent an operator may select, and nothing else. Ordered the way the
+/// settings form should list them, which is also the canonical order a stored
+/// set is sorted into.
+///
+/// These four are exactly the agents `docs/workspaces.md` documents a user
+/// installing by hand, and the four whose state directories the reference
+/// image's entrypoint already keeps on the volume. An agent whose install is
+/// manual upstream (`vibe`, `pi`, `omp`, `kimi`) has nothing to automate here.
+pub const CATALOG: &[WorkspaceAgent] = &[
+    WorkspaceAgent {
+        name: "claude",
+        label: "Claude",
+    },
+    WorkspaceAgent {
+        name: "codex",
+        label: "Codex",
+    },
+    WorkspaceAgent {
+        name: "gemini",
+        label: "Gemini",
+    },
+    WorkspaceAgent {
+        name: "opencode",
+        label: "OpenCode",
+    },
+];
+
+/// The environment variable a workspace receives the set through. Read by the
+/// reference image's entrypoint, not by aoe.
+pub const ENV_VAR: &str = "CITYHALL_AGENTS";
+
+fn known(name: &str) -> bool {
+    CATALOG.iter().any(|a| a.name == name)
+}
+
+/// Canonicalize a submitted set into the single string that is stored,
+/// injected, and recorded as a container label.
+///
+/// One canonical form matters because that string is compared against a running
+/// workspace's label to decide whether it is out of date. Ticking two boxes in
+/// the other order, or twice, must not read as a change, so the set is
+/// deduplicated and sorted into catalog order rather than kept as submitted.
+pub fn canonicalize(requested: &[String]) -> Result<String, AppError> {
+    if let Some(unknown) = requested.iter().find(|n| !known(n)) {
+        tracing::warn!(agent = %unknown, "rejected an unknown coding agent");
+        return Err(AppError::BadRequest("unknown coding agent"));
+    }
+    Ok(CATALOG
+        .iter()
+        .filter(|a| requested.iter().any(|n| n == a.name))
+        .map(|a| a.name)
+        .collect::<Vec<_>>()
+        .join(","))
+}
+
+/// The stored value read back as a list.
+///
+/// A name that is no longer in the catalog is dropped rather than passed on, the
+/// same way a stored credential for a retired variable is: the workspace would
+/// otherwise keep being told to install something nothing knows how to install.
+pub fn parse(stored: &str) -> Vec<String> {
+    stored
+        .split(',')
+        .filter(|n| !n.is_empty())
+        .filter(|n| {
+            let ok = known(n);
+            if !ok {
+                tracing::warn!(agent = %n, "stored coding agent is not in the catalog, skipping it");
+            }
+            ok
+        })
+        .map(String::from)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_is_closed() {
+        assert!(canonicalize(&["claude".to_string()]).is_ok());
+        assert!(canonicalize(&["Claude".to_string()]).is_err());
+        assert!(canonicalize(&["".to_string()]).is_err());
+        // A name that would smuggle a second entry past the entrypoint's split,
+        // or a shell fragment, is not a name in the catalog.
+        assert!(canonicalize(&["claude,codex".to_string()]).is_err());
+        assert!(canonicalize(&["claude; rm -rf /".to_string()]).is_err());
+    }
+
+    /// The stored value is comma-joined and split on commas at both ends, so a
+    /// name containing one would silently become two entries.
+    #[test]
+    fn catalog_names_survive_the_encoding() {
+        assert!(CATALOG
+            .iter()
+            .all(|a| !a.name.contains(',') && !a.name.trim().is_empty()));
+        assert!(CATALOG.iter().all(|a| a.name.trim() == a.name));
+    }
+
+    #[test]
+    fn catalog_has_no_duplicates() {
+        let mut names: Vec<&str> = CATALOG.iter().map(|a| a.name).collect();
+        let count = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), count);
+    }
+
+    /// Order and repetition in the request must not change the stored value, or
+    /// re-saving the same set would read as drift and recreate every workspace.
+    #[test]
+    fn canonical_form_is_order_and_duplicate_insensitive() {
+        let expected = "claude,codex,gemini";
+        for submitted in [
+            vec!["claude", "codex", "gemini"],
+            vec!["gemini", "claude", "codex"],
+            vec!["codex", "codex", "gemini", "claude"],
+        ] {
+            let submitted: Vec<String> = submitted.into_iter().map(String::from).collect();
+            assert_eq!(canonicalize(&submitted).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn an_empty_set_round_trips_as_nothing() {
+        assert_eq!(canonicalize(&[]).unwrap(), "");
+        assert!(parse("").is_empty());
+    }
+
+    #[test]
+    fn parse_drops_names_no_longer_in_the_catalog() {
+        assert_eq!(parse("claude,retired-agent,codex"), vec!["claude", "codex"]);
+    }
+
+    #[test]
+    fn parse_round_trips_a_canonical_value() {
+        let stored = canonicalize(&["opencode".to_string(), "claude".to_string()]).unwrap();
+        assert_eq!(parse(&stored), vec!["claude", "opencode"]);
+    }
+}

--- a/api/src/entities/workspace_settings.rs
+++ b/api/src/entities/workspace_settings.rs
@@ -20,6 +20,10 @@ pub struct Model {
     /// one instead of failing the whole row's deserialization.
     pub telemetry_policy: String,
     pub updated_at: DateTimeUtc,
+    /// Coding agents a workspace should arrive with, as the comma-joined
+    /// canonical form produced by `crate::agents::canonicalize`. Empty means
+    /// users install their own, which is the behaviour without this setting.
+    pub agents: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -2,7 +2,7 @@ use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
 use chrono::Utc;
-use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set};
 use serde::{Deserialize, Serialize};
 
 use crate::auth::AuthUser;
@@ -318,6 +318,15 @@ async fn pin_version(
     Ok(())
 }
 
+/// One agent an operator can ask a workspace to arrive with, for the settings
+/// form to render. The server owns this catalog so the client lists whatever
+/// comes back rather than hardcoding one, the way it does for credentials.
+#[derive(Serialize)]
+pub struct AvailableAgent {
+    pub name: &'static str,
+    pub label: &'static str,
+}
+
 #[derive(Serialize)]
 pub struct WorkspaceSettingsResponse {
     pub image_template: String,
@@ -337,6 +346,11 @@ pub struct WorkspaceSettingsResponse {
     pub telemetry_policy_override: Option<&'static str>,
     /// What workspaces actually run under: the override, or the stored value.
     pub effective_telemetry_policy: &'static str,
+    /// The configured set. Empty means users install their own.
+    pub agents: Vec<String>,
+    /// Everything that could be selected. Response only; sending it back is
+    /// ignored.
+    pub available_agents: Vec<AvailableAgent>,
 }
 
 #[derive(Deserialize)]
@@ -351,6 +365,13 @@ pub struct UpdateWorkspaceSettingsRequest {
     /// they come back on the new policy at their next start.
     #[serde(default)]
     pub restart_running: bool,
+    /// Absent preserves the stored set, `[]` clears it, a list replaces it.
+    ///
+    /// An `Option` rather than a defaulted `Vec` so a client that predates this
+    /// field does not silently wipe an operator's selection just by saving the
+    /// version or the idle timeout. The rest of this body is a full replacement,
+    /// but those fields have always been sent.
+    pub agents: Option<Vec<String>>,
 }
 
 /// The telemetry policy value a save should store.
@@ -393,6 +414,14 @@ pub async fn get_settings(
         image_template: cfg.image_template,
         default_version: cfg.default_version,
         idle_stop_minutes: cfg.idle_stop_minutes,
+        agents: crate::agents::parse(&cfg.agents),
+        available_agents: crate::agents::CATALOG
+            .iter()
+            .map(|a| AvailableAgent {
+                name: a.name,
+                label: a.label,
+            })
+            .collect(),
     }))
 }
 
@@ -403,40 +432,9 @@ pub async fn update_settings(
     Json(body): Json<UpdateWorkspaceSettingsRequest>,
 ) -> Result<Json<WorkspaceSettingsResponse>, AppError> {
     caller.require("settings.write")?;
-    if body.image_template.trim().is_empty() {
-        return Err(AppError::BadRequest("image template is required"));
-    }
-    if body.idle_stop_minutes < 1 {
-        return Err(AppError::BadRequest("idle stop must be at least 1 minute"));
-    }
-    let default_version = normalize(body.default_version);
-
-    let existing = workspace_settings::Entity::find_by_id(SETTINGS_ID)
-        .one(&state.db)
-        .await?;
-    let telemetry_policy = policy_to_store(
-        &body.telemetry_policy,
-        existing.as_ref().map(|r| r.telemetry_policy.as_str()),
-    )?;
-    let agents = existing
-        .as_ref()
-        .map(|e| e.agents.clone())
-        .unwrap_or_default();
-    let model = workspace_settings::ActiveModel {
-        id: Set(SETTINGS_ID),
-        image_template: Set(body.image_template.trim().to_string()),
-        default_version: Set(default_version),
-        idle_stop_minutes: Set(body.idle_stop_minutes),
-        telemetry_policy: Set(telemetry_policy),
-        updated_at: Set(Utc::now()),
-        agents: Set(agents),
-    };
-    if existing.is_some() {
-        model.update(&state.db).await?;
-    } else {
-        model.insert(&state.db).await?;
-    }
-    if body.restart_running {
+    let restart_running = body.restart_running;
+    write_settings(&state.db, body).await?;
+    if restart_running {
         let user_ids = workspace::Entity::find()
             .all(&state.db)
             .await?
@@ -448,9 +446,126 @@ pub async fn update_settings(
     get_settings(State(state), caller).await
 }
 
+/// Validate and persist the settings row. Split out from the handler so the
+/// validation and the preserve-on-absent behaviour are testable without an
+/// authenticated request, the way the credential handlers do it.
+async fn write_settings(
+    db: &DatabaseConnection,
+    body: UpdateWorkspaceSettingsRequest,
+) -> Result<(), AppError> {
+    if body.image_template.trim().is_empty() {
+        return Err(AppError::BadRequest("image template is required"));
+    }
+    if body.idle_stop_minutes < 1 {
+        return Err(AppError::BadRequest("idle stop must be at least 1 minute"));
+    }
+    let default_version = normalize(body.default_version);
+
+    let existing = workspace_settings::Entity::find_by_id(SETTINGS_ID)
+        .one(db)
+        .await?;
+    let telemetry_policy = policy_to_store(
+        &body.telemetry_policy,
+        existing.as_ref().map(|r| r.telemetry_policy.as_str()),
+    )?;
+    let agents = match &body.agents {
+        Some(requested) => crate::agents::canonicalize(requested)?,
+        None => existing
+            .as_ref()
+            .map(|e| e.agents.clone())
+            .unwrap_or_default(),
+    };
+    let model = workspace_settings::ActiveModel {
+        id: Set(SETTINGS_ID),
+        image_template: Set(body.image_template.trim().to_string()),
+        default_version: Set(default_version),
+        idle_stop_minutes: Set(body.idle_stop_minutes),
+        telemetry_policy: Set(telemetry_policy),
+        updated_at: Set(Utc::now()),
+        agents: Set(agents),
+    };
+    if existing.is_some() {
+        model.update(db).await?;
+    } else {
+        model.insert(db).await?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::migration::Migrator;
+    use sea_orm::{ConnectOptions, Database};
+    use sea_orm_migration::MigratorTrait;
+
+    async fn setup() -> DatabaseConnection {
+        let mut opts = ConnectOptions::new("sqlite::memory:");
+        opts.max_connections(1);
+        let db = Database::connect(opts).await.unwrap();
+        Migrator::up(&db, None).await.unwrap();
+        db
+    }
+
+    fn body(agents: Option<Vec<&str>>) -> UpdateWorkspaceSettingsRequest {
+        UpdateWorkspaceSettingsRequest {
+            image_template: "cityhall/aoe:{version}".to_string(),
+            default_version: Some("v1.0.0".to_string()),
+            idle_stop_minutes: 30,
+            telemetry_policy: TelemetryPolicy::default().as_str().to_string(),
+            restart_running: false,
+            agents: agents.map(|a| a.into_iter().map(String::from).collect()),
+        }
+    }
+
+    async fn stored_agents(db: &DatabaseConnection) -> String {
+        crate::workspaces::settings(db).await.unwrap().agents
+    }
+
+    #[tokio::test]
+    async fn an_unknown_agent_is_rejected_and_stores_nothing() {
+        let db = setup().await;
+        let err = write_settings(&db, body(Some(vec!["claude", "not-an-agent"])))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::BadRequest(_)));
+        // The whole save is refused rather than the good half being kept, so a
+        // typo cannot half-apply.
+        assert_eq!(stored_agents(&db).await, "");
+    }
+
+    #[tokio::test]
+    async fn a_selection_is_stored_canonically() {
+        let db = setup().await;
+        write_settings(&db, body(Some(vec!["opencode", "claude", "claude"])))
+            .await
+            .unwrap();
+        assert_eq!(stored_agents(&db).await, "claude,opencode");
+    }
+
+    /// A client that predates this field must not wipe the operator's selection
+    /// just by saving the default version or the idle timeout.
+    #[tokio::test]
+    async fn omitting_the_field_preserves_the_stored_set() {
+        let db = setup().await;
+        write_settings(&db, body(Some(vec!["claude"])))
+            .await
+            .unwrap();
+        write_settings(&db, body(None)).await.unwrap();
+        assert_eq!(stored_agents(&db).await, "claude");
+    }
+
+    /// Sending an empty list is how the set is actually cleared, which has to
+    /// stay distinguishable from not sending the field at all.
+    #[tokio::test]
+    async fn an_empty_list_clears_the_stored_set() {
+        let db = setup().await;
+        write_settings(&db, body(Some(vec!["claude"])))
+            .await
+            .unwrap();
+        write_settings(&db, body(Some(vec![]))).await.unwrap();
+        assert_eq!(stored_agents(&db).await, "");
+    }
 
     /// The whole point of keeping the stored policy a raw string: an admin on an
     /// older CityHall, which reads a policy it does not know as `user_choice`,

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -418,6 +418,10 @@ pub async fn update_settings(
         &body.telemetry_policy,
         existing.as_ref().map(|r| r.telemetry_policy.as_str()),
     )?;
+    let agents = existing
+        .as_ref()
+        .map(|e| e.agents.clone())
+        .unwrap_or_default();
     let model = workspace_settings::ActiveModel {
         id: Set(SETTINGS_ID),
         image_template: Set(body.image_template.trim().to_string()),
@@ -425,6 +429,7 @@ pub async fn update_settings(
         idle_stop_minutes: Set(body.idle_stop_minutes),
         telemetry_policy: Set(telemetry_policy),
         updated_at: Set(Utc::now()),
+        agents: Set(agents),
     };
     if existing.is_some() {
         model.update(&state.db).await?;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,4 +1,5 @@
 mod agent_credentials;
+mod agents;
 mod auth;
 mod cli;
 mod crypto;

--- a/api/src/migration/m0011_create_workspaces.rs
+++ b/api/src/migration/m0011_create_workspaces.rs
@@ -81,4 +81,6 @@ pub enum WorkspaceSettings {
     UpdatedAt,
     /// Added by m0015; declared here so the iden stays with its table.
     TelemetryPolicy,
+    /// Added by m0016; declared here so the iden stays with its table.
+    Agents,
 }

--- a/api/src/migration/m0016_add_agents_to_workspace_settings.rs
+++ b/api/src/migration/m0016_add_agents_to_workspace_settings.rs
@@ -1,0 +1,35 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::schema::*;
+
+use super::m0011_create_workspaces::WorkspaceSettings;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Empty by default, which is the behaviour every existing install
+        // already has: the workspace ships no coding agent and the user installs
+        // the one they want. Only an operator who fills this in changes anything.
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WorkspaceSettings::Table)
+                    .add_column(string(WorkspaceSettings::Agents).default(""))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(WorkspaceSettings::Table)
+                    .drop_column(WorkspaceSettings::Agents)
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/api/src/migration/mod.rs
+++ b/api/src/migration/mod.rs
@@ -15,6 +15,7 @@ mod m0012_create_workspace_config;
 mod m0013_create_agent_credentials;
 mod m0014_create_git_ssh_keys;
 mod m0015_add_workspace_telemetry_policy;
+mod m0016_add_agents_to_workspace_settings;
 
 pub struct Migrator;
 
@@ -37,6 +38,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0013_create_agent_credentials::Migration),
             Box::new(m0014_create_git_ssh_keys::Migration),
             Box::new(m0015_add_workspace_telemetry_policy::Migration),
+            Box::new(m0016_add_agents_to_workspace_settings::Migration),
         ]
     }
 }

--- a/api/src/orchestrator/docker.rs
+++ b/api/src/orchestrator/docker.rs
@@ -113,6 +113,7 @@ impl DockerCliOrchestrator {
                     network_label: labels.get("cityhall.workspace.network").cloned(),
                     env_label: labels.get("cityhall.workspace.env").cloned(),
                     telemetry_label: labels.get("cityhall.workspace.telemetry").cloned(),
+                    agents_label: labels.get("cityhall.workspace.agents").cloned(),
                 }))
             }
             None => Ok(None),
@@ -354,13 +355,16 @@ fn log_tail(path: &std::path::Path) -> String {
 
 /// `KEY=value` lines for everything the workspace's environment needs: the
 /// bundle location and token (when configured), the telemetry policy's own
-/// variables, then every agent credential. One line per pair, in that order;
+/// variables, the coding agents to install (when any), then every agent
+/// credential. One line per pair, in that order;
 /// `agent_credentials::validate_value` guarantees a value can contain no NUL,
 /// newline, or carriage return before it ever reaches here, which this
-/// line-oriented format depends on.
+/// line-oriented format depends on, and the agent set is a canonical join of
+/// catalog names that cannot contain any of the three either.
 ///
-/// The policy's variables are not secret, but they ride the same file rather
-/// than a second `-e` mechanism: one place builds this container's environment.
+/// Neither the policy's variables nor the agent set is secret, and both could
+/// have travelled as plain `-e` pairs, but they ride the same file: one place
+/// builds this container's environment rather than two.
 fn env_file_contents(spec: &WorkspaceSpec) -> String {
     let mut out = String::new();
     if let Some(bundle) = &spec.bundle {
@@ -369,6 +373,9 @@ fn env_file_contents(spec: &WorkspaceSpec) -> String {
     }
     for (name, value) in spec.telemetry.env_pairs() {
         out.push_str(&format!("{name}={value}\n"));
+    }
+    if !spec.agents.is_empty() {
+        out.push_str(&format!("{}={}\n", crate::agents::ENV_VAR, spec.agents));
     }
     for (name, value) in &spec.agent_env.pairs {
         out.push_str(&format!("{name}={}\n", value.expose()));
@@ -464,6 +471,14 @@ fn run_args(spec: &WorkspaceSpec, network: Option<&str>, env_file: Option<&Path>
         // runs under, and a policy change is not a credential change.
         "--label".into(),
         format!("cityhall.workspace.telemetry={}", spec.telemetry.as_str()),
+        // The agent set the container was created with. Recorded rather than
+        // derived from the environment because `docker start` reuses a stopped
+        // container's stored environment, so without this a container would
+        // never see a changed set. Empty (never absent) for the same reason the
+        // env label is: a pre-feature container's absent label and an
+        // unconfigured set have to compare equal.
+        "--label".into(),
+        format!("cityhall.workspace.agents={}", spec.agents),
         "-v".into(),
         format!("{volume}:{AOE_DATA_DIR}"),
     ];
@@ -589,25 +604,28 @@ struct ContainerState {
     network_label: Option<String>,
     env_label: Option<String>,
     telemetry_label: Option<String>,
+    agents_label: Option<String>,
 }
 
 /// Whether a running container must be recreated rather than reused or
 /// resumed: the pinned version changed, the addressing mode changed, the
-/// injected credential set changed, or the telemetry policy changed. Extracted
-/// as a pure function so the drift conditions are testable without a docker
-/// daemon.
+/// injected credential set changed, the telemetry policy changed, or the
+/// coding-agent set changed. Extracted as a pure function so the drift
+/// conditions are testable without a docker daemon.
 ///
-/// The env label is absent on any container created before credentials were
-/// injected. Treating that absence as the empty string means a user with no
-/// stored credentials (whose fingerprint is also empty) is never recreated on
-/// upgrade just because the label didn't exist yet. The telemetry label is
-/// absent for the same reason and reads as `user_choice`, which is what a
-/// container created before the policy existed effectively runs under, so
-/// again nothing is recreated by the upgrade alone.
+/// The env, telemetry, and agents labels are absent on any container created
+/// before the feature that added each. Treating those absences as the empty
+/// string (or, for telemetry, as `user_choice`) means a user with no stored
+/// credentials, a container predating the policy, and an install with no
+/// configured agents are all left alone rather than recreated by an upgrade.
 ///
-/// The policy has to be here and not only in the create path: a stopped
-/// container is otherwise resumed with `docker start`, which reuses its stored
-/// environment, and a policy change would never reach it.
+/// The policy and the agent set both have to be here and not only in the create
+/// path: a stopped container is otherwise resumed with `docker start`, which
+/// reuses its stored environment, so a change to either would never reach it.
+/// The agent set therefore drifts like a credential does rather than more
+/// gently; the endpoint cache means a workspace being actively used is not
+/// reconciled at all until it is stopped, restarted, or CityHall itself
+/// restarts.
 fn needs_recreate(state: &ContainerState, spec: &WorkspaceSpec, network: Option<&str>) -> bool {
     let telemetry = state
         .telemetry_label
@@ -618,6 +636,7 @@ fn needs_recreate(state: &ContainerState, spec: &WorkspaceSpec, network: Option<
         || state.network_label.as_deref() != network
         || state.env_label.as_deref().unwrap_or("") != spec.agent_env.fingerprint
         || telemetry != spec.telemetry
+        || state.agents_label.as_deref().unwrap_or("") != spec.agents
 }
 
 #[derive(Deserialize)]
@@ -831,6 +850,13 @@ mod tests {
         }
     }
 
+    fn spec_with_agents() -> WorkspaceSpec {
+        WorkspaceSpec {
+            agents: "claude,codex".to_string(),
+            ..spec()
+        }
+    }
+
     /// Force-off is delivered as `DO_NOT_TRACK`, which aoe treats as absolute,
     /// and leaves the command alone. The other two policies inject nothing.
     #[test]
@@ -920,6 +946,7 @@ mod tests {
             // Absent, like a container created before the policy existed. The
             // telemetry cases below set it explicitly.
             telemetry_label: None,
+            agents_label: None,
         }
     }
 
@@ -943,6 +970,73 @@ mod tests {
 
         let current = container_state("v1.0.0", None, Some(&spec.agent_env.fingerprint));
         assert!(!needs_recreate(&current, &spec, None));
+    }
+
+    /// The workspace only learns which agents to install from its environment,
+    /// and `docker start` cannot change a stopped container's environment, so
+    /// the set has to be there at create time or the feature does nothing.
+    #[test]
+    fn the_agent_set_reaches_the_container_environment() {
+        let contents = env_file_contents(&spec_with_agents());
+        assert!(
+            contents
+                .lines()
+                .any(|l| l == "CITYHALL_AGENTS=claude,codex"),
+            "{contents}"
+        );
+        // Nothing configured must not define the variable at all, so the
+        // entrypoint's install loop has nothing to iterate.
+        assert_eq!(env_file_contents(&spec()), "");
+    }
+
+    /// An install that has never configured this has no agents label on its
+    /// containers and no configured set. Those two must compare equal, or
+    /// upgrading CityHall would recreate every workspace once for nothing.
+    #[test]
+    fn absent_agents_label_and_empty_set_do_not_trigger_recreate() {
+        let spec = spec();
+        assert_eq!(spec.agents, "");
+        let state = container_state("v1.0.0", None, None);
+        assert!(state.agents_label.is_none());
+        assert!(!needs_recreate(&state, &spec, None));
+    }
+
+    /// Adding or removing an agent has to reach existing workspaces. Without
+    /// this, a stopped container would be resumed with its old environment
+    /// forever and an admin's change would only ever apply to new users.
+    #[test]
+    fn a_differing_agents_label_triggers_recreate() {
+        let spec = spec_with_agents();
+
+        let mut stale = container_state("v1.0.0", None, None);
+        stale.agents_label = Some("claude".to_string());
+        assert!(needs_recreate(&stale, &spec, None));
+
+        // Deselecting everything is a change too, not a return to "unset".
+        let mut emptied = container_state("v1.0.0", None, None);
+        emptied.agents_label = Some(String::new());
+        assert!(needs_recreate(&emptied, &spec, None));
+
+        let mut current = container_state("v1.0.0", None, None);
+        current.agents_label = Some(spec.agents.clone());
+        assert!(!needs_recreate(&current, &spec, None));
+    }
+
+    /// The label is what makes the set comparable at all, so it has to be on
+    /// the create command, and empty rather than absent when nothing is set.
+    #[test]
+    fn run_args_record_the_agent_set_as_a_label() {
+        let args = run_args(&spec_with_agents(), None, None);
+        assert!(
+            args.iter()
+                .any(|a| a == "cityhall.workspace.agents=claude,codex"),
+            "{args:?}"
+        );
+        let args = run_args(&spec(), None, None);
+        assert!(
+            args.iter().any(|a| a == "cityhall.workspace.agents="),
+            "{args:?}"
+        );
     }
 
     #[test]

--- a/api/src/orchestrator/docker.rs
+++ b/api/src/orchestrator/docker.rs
@@ -692,6 +692,7 @@ mod tests {
             bundle: None,
             agent_env: crate::agent_credentials::AgentEnv::default(),
             telemetry: TelemetryPolicy::default(),
+            agents: String::new(),
         }
     }
 

--- a/api/src/orchestrator/kubernetes.rs
+++ b/api/src/orchestrator/kubernetes.rs
@@ -490,6 +490,7 @@ mod tests {
             bundle: None,
             agent_env: crate::agent_credentials::AgentEnv::default(),
             telemetry: TelemetryPolicy::default(),
+            agents: String::new(),
         }
     }
 

--- a/api/src/orchestrator/kubernetes.rs
+++ b/api/src/orchestrator/kubernetes.rs
@@ -349,6 +349,14 @@ fn render_manifests(
         "volumeMounts": [{ "name": "data", "mountPath": AOE_DATA_DIR }],
     });
 
+    // Which coding agents to install is not a secret, so it goes straight on the
+    // container rather than into the per-user Secret the credentials use. Only
+    // emitted when something is configured, so a pod template without the
+    // feature in use is byte-identical to what it was before.
+    if !spec.agents.is_empty() {
+        container["env"] = json!([{ "name": crate::agents::ENV_VAR, "value": spec.agents }]);
+    }
+
     let env_values = env_values(spec);
     let mut items = vec![
         json!({
@@ -402,6 +410,14 @@ fn render_manifests(
     // every pod in the namespace for a setting nobody has touched yet.
     if spec.telemetry != TelemetryPolicy::UserChoice {
         annotations["cityhall.workspace/telemetry-policy"] = json!(spec.telemetry.as_str());
+    }
+    // The agent set already changes the pod template through the container's
+    // `env` above, so this is not what makes a change roll. It is here so the
+    // applied set is readable on the Deployment without diffing container
+    // environments, the way the version annotation is. Written only when a set is
+    // configured, for the same reason the telemetry annotation is.
+    if !spec.agents.is_empty() {
+        annotations["cityhall.workspace/agents"] = json!(spec.agents);
     }
 
     items.push(json!({
@@ -622,6 +638,13 @@ mod tests {
         assert_eq!(container["args"][1], "serve");
         // Nothing to inject: no envFrom referencing a Secret that does not exist.
         assert!(container.get("envFrom").is_none());
+        // No agents configured: neither the env nor the annotation is written, so
+        // a pod template for an install not using the feature is byte-identical
+        // to what it was before the feature existed and no pod rolls on upgrade.
+        assert!(container.get("env").is_none());
+        assert!(dep["spec"]["template"]["metadata"]["annotations"]
+            .get("cityhall.workspace/agents")
+            .is_none());
         assert_eq!(
             container["volumeMounts"][0]["mountPath"],
             "/home/aoe/.config/agent-of-empires"
@@ -748,6 +771,31 @@ mod tests {
             .find(|i| i["kind"] == "Secret")
             .expect("force-off has a variable to inject, so a Secret is emitted");
         assert_eq!(secret["stringData"]["DO_NOT_TRACK"], "1");
+    }
+
+    /// The agent set is not a credential: it belongs on the container, not in
+    /// the per-user Secret. It still has to change the pod template, or an
+    /// admin's change would apply to nothing that already exists.
+    #[test]
+    fn the_agent_set_is_plain_pod_environment_and_rolls_the_deployment() {
+        let spec = WorkspaceSpec {
+            agents: "claude,codex".to_string(),
+            ..spec()
+        };
+        let m = render_manifests(&spec, "cityhall", "5Gi", None);
+        let items = m["items"].as_array().unwrap();
+        // Agents alone are not a reason to emit a Secret.
+        assert!(!items.iter().any(|i| i["kind"] == "Secret"));
+
+        let dep = items.iter().find(|i| i["kind"] == "Deployment").unwrap();
+        let container = &dep["spec"]["template"]["spec"]["containers"][0];
+        assert_eq!(container["env"][0]["name"], "CITYHALL_AGENTS");
+        assert_eq!(container["env"][0]["value"], "claude,codex");
+        assert!(container.get("envFrom").is_none());
+        assert_eq!(
+            dep["spec"]["template"]["metadata"]["annotations"]["cityhall.workspace/agents"],
+            "claude,codex"
+        );
     }
 
     #[test]

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -33,6 +33,17 @@ pub struct WorkspaceSpec {
     pub agent_env: crate::agent_credentials::AgentEnv,
     /// The deployment's telemetry policy, applied at every start.
     pub telemetry: TelemetryPolicy,
+    /// Coding agents the workspace should arrive with, in the canonical
+    /// comma-joined form `crate::agents` produces. Delivered to the workspace as
+    /// an environment variable the reference image's entrypoint acts on, and
+    /// recorded on the runtime object so a change to the set is detectable as
+    /// drift. Empty means the workspace installs nothing and the user installs
+    /// their own, which is the behaviour before this existed.
+    ///
+    /// A plain `String` rather than a `Vec`: it is one value to compare against
+    /// what a running workspace was created with, and splitting it only to join
+    /// it again in every backend would be two representations that can disagree.
+    pub agents: String,
 }
 
 /// Who decides whether a workspace sends aoe telemetry (#40).

--- a/api/src/orchestrator/process.rs
+++ b/api/src/orchestrator/process.rs
@@ -650,6 +650,7 @@ mod tests {
             bundle: None,
             agent_env: crate::agent_credentials::AgentEnv::default(),
             telemetry: TelemetryPolicy::default(),
+            agents: String::new(),
         }
     }
 

--- a/api/src/orchestrator/process.rs
+++ b/api/src/orchestrator/process.rs
@@ -773,6 +773,7 @@ mod tests {
             bundle: None,
             agent_env: crate::agent_credentials::AgentEnv::default(),
             telemetry: TelemetryPolicy::default(),
+            agents: String::new(),
         };
         // A recent failed download attempt is surfaced as guidance instead of
         // re-spawning a download on every request.

--- a/api/src/workspaces.rs
+++ b/api/src/workspaces.rs
@@ -30,6 +30,7 @@ pub async fn settings(db: &DatabaseConnection) -> Result<workspace_settings::Mod
             idle_stop_minutes: 30,
             telemetry_policy: TelemetryPolicy::default().as_str().to_string(),
             updated_at: Utc::now(),
+            agents: String::new(),
         }))
 }
 
@@ -85,6 +86,7 @@ async fn apply_seeded_version(db: &DatabaseConnection, version: String) -> Resul
         idle_stop_minutes: Set(defaults.idle_stop_minutes),
         telemetry_policy: Set(defaults.telemetry_policy),
         updated_at: Set(Utc::now()),
+        agents: Set(defaults.agents),
     }
     .insert(db)
     .await?;
@@ -298,6 +300,10 @@ pub fn build_spec(
         bundle,
         agent_env: crate::agent_credentials::AgentEnv::default(),
         telemetry: effective_telemetry_policy(settings),
+        // Already canonical on the way in, so it is passed through rather than
+        // re-derived: the backends compare this exact string against what a
+        // running workspace was created with.
+        agents: settings.agents.clone(),
     })
 }
 
@@ -530,6 +536,7 @@ mod tests {
             idle_stop_minutes: 30,
             telemetry_policy: TelemetryPolicy::default().as_str().to_string(),
             updated_at: Utc::now(),
+            agents: String::new(),
         }
     }
 
@@ -555,6 +562,7 @@ mod tests {
             idle_stop_minutes: Set(30),
             telemetry_policy: Set(TelemetryPolicy::default().as_str().to_string()),
             updated_at: Set(Utc::now()),
+            agents: Set(String::new()),
         }
         .insert(&db)
         .await
@@ -592,6 +600,27 @@ mod tests {
         let s = settings(&db).await.unwrap();
         assert_eq!(s.image_template, "cityhall/aoe:{version}");
         assert_eq!(s.idle_stop_minutes, 30);
+        // No agents by default: an install that has never configured this keeps
+        // shipping a workspace the user installs their own agent into.
+        assert_eq!(s.agents, "");
+    }
+
+    /// The workspace has to be told which agents to arrive with, and it is told
+    /// through the spec, so a settings value that stopped reaching it here would
+    /// silently turn the whole feature off.
+    #[tokio::test]
+    async fn spec_carries_the_configured_agents() {
+        let db = setup().await;
+        let uid = make_user(&db).await;
+        let row = get_or_create(&db, uid).await.unwrap();
+        assert_eq!(build_spec(&cfg(Some("v1.0.0")), &row).unwrap().agents, "");
+
+        let mut with_agents = cfg(Some("v1.0.0"));
+        with_agents.agents = "claude,codex".to_string();
+        assert_eq!(
+            build_spec(&with_agents, &row).unwrap().agents,
+            "claude,codex"
+        );
     }
 
     #[tokio::test]

--- a/deploy/aoe-image/Dockerfile
+++ b/deploy/aoe-image/Dockerfile
@@ -27,8 +27,13 @@
 #
 # The image ships no coding agent. A user installs the one they want from
 # inside their workspace, and `entrypoint.sh` keeps that install and the
-# agent's login on the volume so both survive a container recreate. An operator
-# who wants a fixed set builds a derived image; see docs/workspaces.md.
+# agent's login on the volume so both survive a container recreate.
+#
+# An operator can instead name a set in CityHall's workspace settings, which
+# arrives as `CITYHALL_AGENTS` and is installed at boot by
+# `provision-agents.sh` below. That still installs at run time; an operator who
+# wants the set baked in, with no boot-time network at all, builds a derived
+# image. See docs/workspaces.md.
 
 # Which stage supplies /out/aoe: `release` downloads a published tarball,
 # `git` compiles a commit from source. Declared before the first FROM so a
@@ -160,8 +165,12 @@ FROM aoe-${AOE_SOURCE} AS aoe-binary
 # gemini, pi). aoe's floor is Node 20 and its own container image uses 22.
 FROM node:22-bookworm-slim
 
+# tini is PID 1 so a coding-agent install kicked off at boot has something to
+# reap it. It is deliberately orphaned before aoe starts (see
+# `provision-agents.sh` below), and an orphan is adopted by PID 1, which aoe is
+# not equipped to be.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl git tmux \
+    && apt-get install -y --no-install-recommends ca-certificates curl git tini tmux \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=aoe-binary /out/aoe /usr/local/bin/aoe
@@ -239,9 +248,132 @@ link npm           .npm-global           dir
 link local-bin     .local/bin            dir
 link opencode-home .opencode             dir
 
+# Install the coding agents CityHall was told this workspace should arrive with,
+# if any. Deliberately not in the foreground: CityHall gives a workspace 15
+# seconds to answer HTTP before it calls the start failed, and an `npm install
+# -g` takes minutes, so installing here before `exec` would make every first
+# start fail. Backgrounded, the workspace is usable immediately and the agents
+# appear shortly after.
+#
+# The extra subshell is what makes it safe to leave running. `cmd &` alone would
+# leave the installer a child of this shell, whose pid becomes aoe's after the
+# `exec` below, and aoe does not reap children. Backgrounding inside a subshell
+# that exits immediately orphans the installer, so PID 1 adopts it, and PID 1 is
+# tini.
+#
+# The environment is scrubbed rather than inherited. These installers are
+# third-party code, and this container's environment holds the user's provider
+# API keys and the bearer token that fetches their whole CityHall config bundle,
+# including their decrypted git token. None of that is needed to install a
+# package.
+if [ -n "${CITYHALL_AGENTS:-}" ]; then
+    mkdir -p "$STORE"
+    (
+        env -i \
+            HOME="$HOME" \
+            PATH="$PATH" \
+            NPM_CONFIG_PREFIX="${NPM_CONFIG_PREFIX:-}" \
+            CITYHALL_AGENTS="$CITYHALL_AGENTS" \
+            STORE="$STORE" \
+            /usr/local/bin/provision-agents.sh \
+            </dev/null >>"$STORE/provision.log" 2>&1 &
+    )
+fi
+
 exec "$@"
 SH
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Installs the agents named in CITYHALL_AGENTS. Runs detached from the
+# entrypoint, so nothing here can delay or fail the workspace's start.
+#
+# A name is never interpolated into a command: the `case` below is the whole
+# name-to-command map, and a name that matches no branch installs nothing. That
+# is what makes it safe for the set to come from a CityHall setting.
+#
+# Success is recorded in a marker file on the volume, and only after the binary
+# is actually on PATH. Two things follow. An install that was cut short (an idle
+# stop mid-download) leaves no marker and is retried on the next start, where
+# checking the binary alone could see a bin symlink over an unusable tree and
+# skip it forever. And an agent a user later removes stays removed: this
+# installs a default once, it does not police what the user does afterwards.
+COPY <<"SH" /usr/local/bin/provision-agents.sh
+#!/bin/sh
+# No `set -e`: one agent failing to install must not skip the rest, and must
+# never be the reason a workspace is short of the others.
+
+MARKERS="$STORE/provisioned"
+
+done_already() {
+    [ -f "$MARKERS" ] && grep -qx "$1" "$MARKERS"
+}
+
+# Bounded so a hung download, or an installer that decides to prompt on a
+# terminal that is not there, cannot sit in the container for its whole life.
+run() {
+    timeout 10m sh -c "$1" </dev/null
+}
+
+install_agent() {
+    case "$1" in
+    claude)
+        binary=claude-agent-acp
+        command='npm install -g @agentclientprotocol/claude-agent-acp@latest'
+        ;;
+    codex)
+        binary=codex-acp
+        command='npm install -g @agentclientprotocol/codex-acp@latest'
+        ;;
+    gemini)
+        binary=gemini
+        command='npm install -g @google/gemini-cli'
+        ;;
+    opencode)
+        binary=opencode
+        # Downloaded and then run, rather than piped into a shell: a pipe hides
+        # whether the download itself failed, so a truncated script or an error
+        # page would be executed as an installer. It is still a script fetched
+        # at install time, which is what upstream publishes.
+        #
+        # bash, not sh: the script upstream serves uses `set -o pipefail`, which
+        # dash rejects, so running it with /bin/sh fails on its second line.
+        command='curl -fsSL -o /tmp/opencode-install.sh https://opencode.ai/install \
+                 && bash /tmp/opencode-install.sh; rc=$?; rm -f /tmp/opencode-install.sh; exit $rc'
+        ;;
+    *)
+        echo "unknown coding agent '$1', skipping it"
+        return 0
+        ;;
+    esac
+
+    if command -v "$binary" >/dev/null 2>&1; then
+        # Already there, from an earlier boot, a derived image, or the user's own
+        # install. Recorded so a later removal is not undone on the next start.
+        echo "$1 is already installed"
+        echo "$1" >>"$MARKERS"
+        return 0
+    fi
+
+    echo "installing $1"
+    if ! run "$command"; then
+        echo "could not install $1; the workspace is running without it"
+        return 0
+    fi
+    if ! command -v "$binary" >/dev/null 2>&1; then
+        echo "installing $1 reported success but left no $binary on PATH"
+        return 0
+    fi
+    echo "$1" >>"$MARKERS"
+    echo "installed $1"
+}
+
+echo "--- $(date -u '+%Y-%m-%dT%H:%M:%SZ') provisioning: $CITYHALL_AGENTS"
+IFS=,
+for agent in $CITYHALL_AGENTS; do
+    done_already "$agent" || install_agent "$agent"
+done
+SH
+RUN chmod +x /usr/local/bin/provision-agents.sh
 
 USER aoe
 ENV HOME=/home/aoe
@@ -253,6 +385,10 @@ ENV PATH=/home/aoe/.npm-global/bin:/home/aoe/.local/bin:/home/aoe/.opencode/bin:
 
 # CityHall passes the full `aoe serve ...` command as arguments, so the
 # entrypoint runs first and then execs it.
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+#
+# tini is in front so PID 1 reaps the orphaned agent install; `-g` sends a stop
+# signal to the whole process group rather than aoe alone, so an install still
+# running is torn down with the container instead of being left to race it.
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "/usr/local/bin/entrypoint.sh"]
 
 EXPOSE 8080

--- a/deploy/aoe-image/Dockerfile
+++ b/deploy/aoe-image/Dockerfile
@@ -282,6 +282,7 @@ fi
 
 exec "$@"
 SH
+
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # Installs the agents named in CITYHALL_AGENTS. Runs detached from the
@@ -373,6 +374,7 @@ for agent in $CITYHALL_AGENTS; do
     done_already "$agent" || install_agent "$agent"
 done
 SH
+
 RUN chmod +x /usr/local/bin/provision-agents.sh
 
 USER aoe

--- a/docs/api.md
+++ b/docs/api.md
@@ -500,11 +500,19 @@ Requires `settings.read`.
 `available_agents` is the whole selectable catalog, so a client lists that rather
 than hardcoding one.
 
+`telemetry_policy` is the stored policy verbatim, while
+`telemetry_policy_override` is set only when `WORKSPACE_TELEMETRY_POLICY` pins one
+for the deployment, and `effective_telemetry_policy` is what workspaces actually
+run under.
+
 ```json
 {
   "image_template": "cityhall/aoe:{version}",
   "default_version": "v0.5.0",
   "idle_stop_minutes": 30,
+  "telemetry_policy": "user_choice",
+  "telemetry_policy_override": null,
+  "effective_telemetry_policy": "user_choice",
   "agents": ["claude"],
   "available_agents": [
     { "name": "claude", "label": "Claude" },
@@ -517,8 +525,12 @@ than hardcoding one.
 
 ### `PUT /api/settings/workspaces`
 
-Requires `settings.write`. Same shape as `GET` minus `available_agents`, which is
-the server's catalog rather than a setting and is ignored if sent.
+Requires `settings.write`. Takes `image_template`, `default_version`,
+`idle_stop_minutes`, `telemetry_policy`, `agents`, and `restart_running`. The
+three fields the server derives, `telemetry_policy_override`,
+`effective_telemetry_policy`, and `available_agents`, are not settings and are
+ignored if sent.
+
 `image_template` is required; `idle_stop_minutes` must be at least 1. A name in
 `agents` that is not in the catalog is rejected with 400 and nothing is stored.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -496,18 +496,36 @@ one call.
 
 Requires `settings.read`.
 
+`agents` is the coding agents a workspace is set up to arrive with, and
+`available_agents` is the whole selectable catalog, so a client lists that rather
+than hardcoding one.
+
 ```json
 {
   "image_template": "cityhall/aoe:{version}",
   "default_version": "v0.5.0",
-  "idle_stop_minutes": 30
+  "idle_stop_minutes": 30,
+  "agents": ["claude"],
+  "available_agents": [
+    { "name": "claude", "label": "Claude" },
+    { "name": "codex", "label": "Codex" },
+    { "name": "gemini", "label": "Gemini" },
+    { "name": "opencode", "label": "OpenCode" }
+  ]
 }
 ```
 
 ### `PUT /api/settings/workspaces`
 
-Requires `settings.write`. Same shape as `GET`. `image_template` is required;
-`idle_stop_minutes` must be at least 1.
+Requires `settings.write`. Same shape as `GET` minus `available_agents`, which is
+the server's catalog rather than a setting and is ignored if sent.
+`image_template` is required; `idle_stop_minutes` must be at least 1. A name in
+`agents` that is not in the catalog is rejected with 400 and nothing is stored.
+
+`agents` is optional, and the three cases differ: omitting it preserves the
+stored set, `[]` clears it, and a list replaces it. Omission preserves rather
+than clears so a client that predates the field cannot wipe the selection just by
+saving the idle timeout.
 
 ### `GET /api/me/agent-credentials`
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -257,8 +257,7 @@ until it is upgraded.
 
 **The reference image ships no coding agent.** It carries the aoe binary, git,
 tmux, and a Node runtime, and nothing else. Which agent a workspace runs is the
-user's choice, made per session in aoe's own session wizard, so CityHall does not
-duplicate that as a setting.
+user's choice, made per session in aoe's own session wizard.
 
 A user installs the agent they want from a terminal session inside their
 workspace. aoe prints the exact command when a chosen agent is missing, so
@@ -282,36 +281,74 @@ symlinks: `~/.claude`, `~/.claude.json`, `~/.codex`, `~/.gemini`,
 structured-view agent, so an env-based approach would work in a terminal session
 and quietly fail in structured view.
 
-CityHall does not own agent versions. An install without a pinned version tracks
-whatever the registry serves.
+#### Handing users a workspace that is already set up
 
-To set the default agent for every workspace, put it in the workspace config
-document (**Settings → Workspaces**):
+Tick the agents under **Settings → Workspaces** and a workspace installs them
+itself, so a user opens one that is ready to use instead of installing something
+first. Leave them all unticked and nothing is installed, which is the behaviour
+above.
+
+Four things are worth knowing before turning it on.
+
+**The install happens at boot, in the background.** CityHall gives a workspace
+15 seconds to answer HTTP before it treats the start as failed, and an
+`npm install -g` takes minutes, so the workspace comes up first and the agents
+land shortly after. A user who opens a brand new workspace within the first
+minute or so may still find an agent missing; it appears without them doing
+anything. Progress and failures are logged inside the workspace, at
+`~/.config/agent-of-empires/cityhall-agents/provision.log`.
+
+**It adds a network dependency to a cold start.** A registry outage means the
+workspace starts without the agent it was supposed to have rather than failing
+to start. The cost is paid once per user, because the install lands on the
+persistent volume, so later starts install nothing. An operator who wants a
+fixed set with no boot-time network at all builds a derived image instead; see
+below.
+
+**A change reaches an existing workspace when that workspace is next created**,
+which is a restart, an idle stop, or a first launch, exactly like a credential
+change. Saving the setting deliberately does not disturb anyone's running
+session. Versions are not pinned: an install tracks whatever the registry serves,
+the same as a user running the command by hand.
+
+**An agent a user removes stays removed.** CityHall records that it installed a
+default once, and does not reinstall it on every start. Unticking an agent does
+not uninstall anything either; it only stops new workspaces from getting it.
+
+To set which agent a new session picks by default, put it in the workspace config
+document (**Settings → Workspace config**):
 
 ```toml
 [settings.acp]
 default_agent = "claude"
 ```
 
-**An operator cannot force a workspace to use a particular agent.** aoe applies
-no allowlist to the agents a session may pick, and a terminal session can run
-whatever is installed regardless, so the set of installed binaries is the only
-real lever. Build a derived image to fix that set:
+**The installed set is a default, not a restriction.** aoe applies no allowlist
+to the agents a session may pick, and a terminal session can run whatever is on
+`PATH` regardless, so an admin choosing the set decides what a workspace *arrives
+with*, not what it is *limited to*. A user can install and run anything else.
+Making a restriction actually hold needs an aoe-side allowlist, tracked in
+[agent-of-empires#3241](https://github.com/agent-of-empires/agent-of-empires/issues/3241),
+and separately a decision about terminal access, since a shell defeats an
+allowlist that only covers the structured view.
+
+For a fixed set with no boot-time install at all, build a derived image:
 
 ```dockerfile
 FROM cityhall/aoe:v0.5.0
 RUN npm install -g @agentclientprotocol/claude-agent-acp@0.64.2
 ```
 
-Point the image template at it, and users get exactly those agents. Having
-CityHall install an admin-chosen set instead of a derived image is tracked in
-[#57](https://github.com/agent-of-empires/cityhall/issues/57); the aoe-side
-allowlist that would make a restriction actually hold is
-[agent-of-empires#3241](https://github.com/agent-of-empires/agent-of-empires/issues/3241).
+Point the image template at it and every workspace starts with exactly that,
+pinned, with nothing fetched at boot. The install prefixes come first on `PATH`,
+so a user can still upgrade a baked-in agent for themselves. This is the right
+choice for a deployment that wants reproducible workspaces; the setting above is
+the right choice for convenience.
 
-The `process` backend has no image and no entrypoint, so agents are installed on
-the host by the operator; each user's `HOME` is already a persistent directory,
-so logins persist there without any of the above.
+The `process` backend has no image and no entrypoint, so **the agent setting does
+nothing there** and agents are installed on the host by the operator; each user's
+`HOME` is already a persistent directory, so logins persist there without any of
+the above.
 
 ### Agent credentials
 
@@ -497,10 +534,11 @@ host. WebSocket upgrade forwarding must be enabled on the external proxy.
 
 - Agent credentials only reach structured-view agents for Claude. See
   [Agent credentials](#agent-credentials).
-- An operator cannot restrict which agent a workspace runs, and cannot have
-  CityHall install a chosen set; the image is the only lever
-  ([#57](https://github.com/agent-of-empires/cityhall/issues/57)). See
-  [Coding agents](#coding-agents).
+- An operator can choose which agents a workspace arrives with, but cannot
+  restrict it to them: a session may pick any agent, and a terminal session can
+  run any binary on `PATH`. Enforcement needs an aoe-side allowlist
+  ([agent-of-empires#3241](https://github.com/agent-of-empires/agent-of-empires/issues/3241)).
+  See [Coding agents](#coding-agents).
 - An SSH key only reaches a workspace running an aoe new enough to install one.
   An older aoe ignores it and `git@` remotes keep failing. See
   [SSH keys](#ssh-keys).

--- a/web/src/components/WorkspaceSettings.test.ts
+++ b/web/src/components/WorkspaceSettings.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { effectiveTelemetryPolicy, isKnownTelemetryPolicy, telemetryOverrideNote } from "./WorkspaceSettings";
+import {
+  effectiveTelemetryPolicy,
+  isKnownTelemetryPolicy,
+  telemetryOverrideNote,
+  toggleAgent,
+} from "./WorkspaceSettings";
+import type { AvailableAgent } from "../lib/api";
+
+const CATALOG: AvailableAgent[] = [
+  { name: "claude", label: "Claude" },
+  { name: "codex", label: "Codex" },
+  { name: "gemini", label: "Gemini" },
+  { name: "opencode", label: "OpenCode" },
+];
 
 // There is no @testing-library/react in this repo, so this covers the one
 // non-obvious predicate behind the settings form: an environment-pinned policy
@@ -40,5 +53,34 @@ describe("effectiveTelemetryPolicy", () => {
     expect(effectiveTelemetryPolicy("force_maybe", null)).toBe("user_choice");
     expect(isKnownTelemetryPolicy("force_maybe")).toBe(false);
     expect(isKnownTelemetryPolicy("force_off")).toBe(true);
+  });
+});
+
+// There is no @testing-library/react in this repo, so this covers the one piece
+// of logic behind the checkbox list rather than rendering it.
+describe("toggleAgent", () => {
+  it("adds an agent", () => {
+    expect(toggleAgent([], CATALOG, "codex", true)).toEqual(["codex"]);
+  });
+
+  it("removes an agent", () => {
+    expect(toggleAgent(["claude", "codex"], CATALOG, "claude", false)).toEqual(["codex"]);
+  });
+
+  // The server stores a canonical set, so a selection sent in a different order
+  // would read as a change and recreate every workspace for nothing.
+  it("keeps the selection in catalog order however it was built", () => {
+    let selected = toggleAgent([], CATALOG, "opencode", true);
+    selected = toggleAgent(selected, CATALOG, "claude", true);
+    selected = toggleAgent(selected, CATALOG, "gemini", true);
+    expect(selected).toEqual(["claude", "gemini", "opencode"]);
+  });
+
+  it("does not duplicate an agent that is already selected", () => {
+    expect(toggleAgent(["claude"], CATALOG, "claude", true)).toEqual(["claude"]);
+  });
+
+  it("unticking the last one clears the selection", () => {
+    expect(toggleAgent(["claude"], CATALOG, "claude", false)).toEqual([]);
   });
 });

--- a/web/src/components/WorkspaceSettings.tsx
+++ b/web/src/components/WorkspaceSettings.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { api, ApiError, type TelemetryPolicy, type WorkspaceSettings } from "../lib/api";
+import { api, ApiError, type AvailableAgent, type TelemetryPolicy, type WorkspaceSettings } from "../lib/api";
 import { isOlderVersion } from "../lib/versions";
 import { Button, ErrorText, Field, Input, Select } from "./ui";
 import { VersionField } from "./VersionField";
@@ -38,6 +38,18 @@ export function effectiveTelemetryPolicy(selected: string, override: TelemetryPo
   return isKnownTelemetryPolicy(selected) ? selected : "user_choice";
 }
 
+/// Tick or untick one agent, keeping the selection in the catalog's order.
+///
+/// Order matters because the server stores a canonical set: sending the same
+/// agents in a different order would otherwise read as a change and recreate
+/// every workspace for nothing.
+export function toggleAgent(selected: string[], catalog: AvailableAgent[], name: string, on: boolean): string[] {
+  const next = new Set(selected);
+  if (on) next.add(name);
+  else next.delete(name);
+  return catalog.filter((a) => next.has(a.name)).map((a) => a.name);
+}
+
 export function WorkspaceSettingsSection() {
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -49,6 +61,8 @@ export function WorkspaceSettingsSection() {
   const [telemetryPolicy, setTelemetryPolicy] = useState<string>("user_choice");
   const [telemetryOverride, setTelemetryOverride] = useState<TelemetryPolicy | null>(null);
   const [restartRunning, setRestartRunning] = useState(false);
+  const [agents, setAgents] = useState<string[]>([]);
+  const [availableAgents, setAvailableAgents] = useState<AvailableAgent[]>([]);
   const [versions, setVersions] = useState<string[]>([]);
   const [latest, setLatest] = useState<string | null>(null);
 
@@ -62,6 +76,11 @@ export function WorkspaceSettingsSection() {
     setIdleStopMinutes(s.idle_stop_minutes);
     setTelemetryPolicy(s.telemetry_policy);
     setTelemetryOverride(s.telemetry_policy_override);
+    // Defaulted rather than trusted: a response missing either list would
+    // otherwise throw during render and take the whole settings page down,
+    // including the sections that have nothing to do with workspaces.
+    setAgents(s.agents ?? []);
+    setAvailableAgents(s.available_agents ?? []);
   }, []);
 
   const load = useCallback(async () => {
@@ -97,6 +116,7 @@ export function WorkspaceSettingsSection() {
           idle_stop_minutes: idleStopMinutes,
           telemetry_policy: telemetryPolicy,
           restart_running: restartRunning,
+          agents,
         }),
       );
       setSaved(true);
@@ -189,6 +209,29 @@ export function WorkspaceSettingsSection() {
           The image for a user is the template with <code className="text-text-primary">{"{version}"}</code> replaced by
           their pinned version (or the default). Idle workspaces are stopped automatically; their data volume is kept.
         </p>
+
+        <div className="space-y-1.5 border-t border-surface-700 pt-4">
+          <span className="font-mono text-xs uppercase tracking-wider text-text-muted">Coding agents</span>
+          <div className="flex flex-wrap gap-x-6 gap-y-2">
+            {availableAgents.map((agent) => (
+              <label key={agent.name} className="flex items-center gap-2 text-sm text-text-primary">
+                <input
+                  type="checkbox"
+                  checked={agents.includes(agent.name)}
+                  onChange={(e) => setAgents(toggleAgent(agents, availableAgents, agent.name, e.target.checked))}
+                  className="h-4 w-4 accent-brand-500"
+                />
+                {agent.label}
+              </label>
+            ))}
+          </div>
+          <p className="text-sm text-text-secondary">
+            Installed the first time a workspace starts, so a user gets one that is ready to use. Leave all of them
+            unticked and users install their own instead. A change reaches an existing workspace the next time it is
+            created, which is a restart, an idle stop, or a first launch. This is a default and not a restriction: a
+            user can still install and run any agent they like.
+          </p>
+        </div>
 
         {/* Only releases are comparable: a custom tag's digits are not a
             version, so "dev-0" would otherwise read as behind the latest. */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -129,6 +129,13 @@ export interface MyWorkspace {
 /// newer CityHall may have written one that is none of these.
 export type TelemetryPolicy = "user_choice" | "force_on" | "force_off";
 
+/// One coding agent a workspace can be set up to arrive with. The server owns
+/// this catalog; the client lists whatever comes back rather than hardcoding it.
+export interface AvailableAgent {
+  name: string;
+  label: string;
+}
+
 export interface WorkspaceSettings {
   image_template: string;
   default_version: string | null;
@@ -143,6 +150,10 @@ export interface WorkspaceSettings {
   telemetry_policy_override: TelemetryPolicy | null;
   /// What workspaces actually run under: the override, or the stored policy.
   effective_telemetry_policy: TelemetryPolicy;
+  /// Selected agents. Empty means users install their own.
+  agents: string[];
+  /// Everything selectable. Response only, so it is not part of a save.
+  available_agents: AvailableAgent[];
 }
 
 /// What a save sends: the settings an admin owns, without the two fields the
@@ -157,6 +168,10 @@ export interface WorkspaceSettingsUpdate {
   /// Recreate every running workspace so a saved policy applies now, which ends
   /// whatever their users are running. Stopped workspaces never need it.
   restart_running: boolean;
+  /// The agents a workspace should arrive with. Absent would preserve whatever is
+  /// stored, which is what an older client relies on; this one always sends the
+  /// selection, so it is required here.
+  agents: string[];
 }
 
 /// The aoe config bundle every workspace is provisioned with. Opaque TOML:


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description
An admin can now tick the coding agents a workspace should arrive with, under **Settings → Workspaces**, and a user opening a fresh workspace finds them installed without doing anything. Leaving them all unticked keeps today's behaviour exactly: the image ships no agent and users install their own.

The chosen set is stored on the singleton workspace settings row, delivered to the workspace as `CITYHALL_AGENTS`, and acted on by the reference image's entrypoint. Only names cross the boundary; the name-to-install-command map lives in the image, so a name that matches no branch installs nothing and nothing an operator selects is ever interpolated into a command. The catalog is closed for the same reason the credential catalog is.

The set is also recorded on the runtime object (a container label, a pod-template annotation), because `docker start` reuses a stopped container's stored environment, so without it an admin's change would only ever reach workspaces that did not exist yet. An absent label compares equal to an empty set, so upgrading does not recreate every existing workspace once for nothing. A change therefore lands when the workspace is next created, which is a restart, an idle stop, or a first launch, exactly like a credential change; saving the setting does not disturb a running session.

Installing happens in the background rather than before aoe starts. CityHall gives a workspace 15 seconds to answer HTTP before it treats the start as failed, and an `npm install -g` takes minutes, so a foreground install would make every first start fail. `tini` becomes PID 1 and the installer is deliberately orphaned into it, because backgrounding without that leaves the installer parented to aoe, which does not reap children. The installers also run with a scrubbed environment: they are third-party code, and a workspace's environment holds the user's provider keys plus the bearer token that fetches their whole config bundle, including their decrypted git token.

Half of what the issue asks for is deliberately not here, and the docs now say so plainly rather than implying otherwise. **The installed set is a default, not a restriction.** aoe applies no allowlist to agent selection and a terminal session can run any binary on `PATH`, so enforcement needs agent-of-empires/agent-of-empires#3241 and, separately, a decision about terminal access. The `process` backend has no image and no entrypoint, so the setting is a documented no-op there, the same way `image_template` already is.

Closes #57

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open **Settings → Workspaces**, tick Claude, save, reload the page, and confirm the tick survives the round trip.
- [ ] `PUT /api/settings/workspaces` with `"agents": ["not-an-agent"]` and confirm a 400, then confirm the previously saved set is untouched.
- [ ] `PUT /api/settings/workspaces` with no `agents` key at all (send only `image_template`, `default_version`, `idle_stop_minutes`) and confirm the saved set is preserved rather than cleared. Then send `"agents": []` and confirm that does clear it.
- [ ] With Claude ticked, launch a fresh workspace, and confirm it answers immediately rather than hanging or failing on the readiness timeout.
- [ ] In a terminal session in that workspace, wait a minute, then run `which claude-agent-acp` and confirm it is on `PATH` without you installing anything. `cat ~/.config/agent-of-empires/cityhall-agents/provision.log` shows what happened.
- [ ] Restart that workspace and confirm the log records no second install, and that the agent is still there.
- [ ] Untick every agent, save, restart a workspace, and confirm nothing is installed and nothing already installed was removed.
- [ ] With the setting empty on an install that never used this, restart a workspace and confirm it is **not** recreated (`docker inspect` shows the same container id), so upgrading does not churn existing workspaces.
- [ ] Add a second agent to the list, restart one user's workspace, and confirm only that workspace is recreated and the new agent appears.

## Checklist

- [x] New and existing tests pass
- [x] `cargo fmt` / `cargo clippy` clean (API changes)
- [x] `npm run lint` / `npm run format:check` clean (web changes)
- [x] Documentation was updated where necessary

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, the `/aoe-implement` skill)

Investigation, plan, and implementation drafted by Claude under my direction, with the plan pressure-tested through `/debate` before any code was written. I made the design calls, including keeping the agent set a hard drift signal rather than adding a soft/hard split that only one backend could honour. Verified by building a stub image and driving real containers: readiness on the first probe while an install ran, zero zombies afterwards, the env scrub, restart idempotency, an interrupted install retrying, a user's removal staying removed, and the install surviving a container recreate. The settings form was driven end to end in a browser against a local CityHall and the canonical value checked in the database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace settings now let administrators select available coding agents, including Claude, Codex, Gemini, and OpenCode.
  - Selected agents are validated, deduplicated, and consistently ordered.
  - Configured agents are provisioned automatically in newly created Docker and Kubernetes workspaces.
  - Agent selections are shown in workspace settings and passed to running environments.

- **Documentation**
  - Added API and workspace documentation covering agent selection, provisioning behavior, defaults, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->