### PR TITLE
feat(dashboard): add a customizable admin dashboard with system usage and container statuses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sysinfo",
  "tokio",
  "toml",
  "tower",
@@ -1872,6 +1873,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,6 +1970,25 @@ dependencies = [
  "sha2",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3453,6 +3482,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4099,6 +4142,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4109,6 +4173,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4138,6 +4213,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -4213,6 +4298,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -37,6 +37,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 # Fingerprints the agent-credential set so a backend can detect drift.
 sha2 = "0.10"
+sysinfo = { version = "0.39", default-features = false, features = ["system", "disk"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "time"] }
 # The workspace config bundle is aoe-owned TOML. CityHall shape-checks it and
 # splices in the per-user `[git]` table; both need a real parser.

--- a/api/src/entities/dashboard_layout.rs
+++ b/api/src/entities/dashboard_layout.rs
@@ -1,0 +1,33 @@
+use sea_orm::entity::prelude::*;
+
+/// A user's admin-dashboard widget layout, as validated JSON text.
+///
+/// Stored per user rather than per browser so a customized dashboard follows
+/// the admin across machines. Only that user ever reads it back.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "dashboard_layouts")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub user_id: i32,
+    pub layout: String,
+    pub updated_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::UserId",
+        to = "super::user::Column::Id",
+        on_delete = "Cascade"
+    )]
+    User,
+}
+
+impl Related<super::user::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/api/src/entities/mod.rs
+++ b/api/src/entities/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_credential;
 pub mod auth_settings;
+pub mod dashboard_layout;
 pub mod git_credential;
 pub mod git_ssh_key;
 pub mod oidc_settings;

--- a/api/src/handlers/dashboard.rs
+++ b/api/src/handlers/dashboard.rs
@@ -1,0 +1,339 @@
+//! Admin dashboard: fleet state, per-workspace usage, and system telemetry.
+//!
+//! This handler does no backend I/O. Every runtime figure comes from the
+//! snapshot the background sampler publishes (see [`crate::metrics`]), so the
+//! cost of a poll is one database read regardless of how many workspaces exist
+//! or how many admins are watching.
+
+use axum::extract::State;
+use axum::Json;
+use chrono::{DateTime, Utc};
+use sea_orm::EntityTrait;
+use serde::Serialize;
+
+use crate::auth::AuthUser;
+use crate::entities::workspace;
+use crate::error::AppError;
+use crate::handlers::workspaces::{runtime_status, ProvisioningInfo};
+use crate::metrics::SystemUsage;
+use crate::orchestrator::{
+    binary_key, render_image, UsageReport, WorkspaceRuntime, WorkspaceUsage,
+};
+use crate::state::AppState;
+use crate::workspaces;
+
+#[derive(Serialize)]
+pub struct DashboardResponse {
+    /// `null` until the sampler's first tick lands, which the UI shows as
+    /// "collecting" rather than as an empty fleet.
+    pub sampled_at: Option<DateTime<Utc>>,
+    /// The sampler looks stuck, not merely between ticks.
+    pub stale: bool,
+    /// Which sources failed on the last tick. The figures beside them are the
+    /// last good ones.
+    pub errors: Vec<String>,
+    pub system: Option<SystemUsage>,
+    /// False only when the backend has no metrics source at all (kubernetes,
+    /// bare process), which the UI states outright instead of showing zeros.
+    /// Before the first sample this is optimistically true and `sampled_at`
+    /// is what tells the UI to say "collecting".
+    pub usage_supported: bool,
+    pub usage: Vec<WorkspaceUsage>,
+    pub workspaces: Vec<DashboardWorkspace>,
+    pub summary: Summary,
+    pub versions: Vec<VersionCount>,
+}
+
+#[derive(Serialize)]
+pub struct DashboardWorkspace {
+    pub user_id: i32,
+    pub username: String,
+    /// `not_created` | `stopped` | `running` | `unknown`.
+    pub status: &'static str,
+    /// What this user should be running, from their pin or the global default.
+    pub effective_version: Option<String>,
+    /// What the runtime object was actually created with, when the backend
+    /// reports it. Differs from `effective_version` while a version change is
+    /// waiting for a restart.
+    pub running_version: Option<String>,
+    pub last_active_at: Option<DateTime<Utc>>,
+    pub provisioning: Option<ProvisioningInfo>,
+}
+
+/// Fleet counts, computed here rather than in the browser so that "running"
+/// means one thing no matter what reads this endpoint.
+#[derive(Debug, Default, PartialEq, Serialize)]
+pub struct Summary {
+    pub total_users: usize,
+    pub running: usize,
+    pub stopped: usize,
+    pub not_created: usize,
+    pub unknown: usize,
+    pub provisioning: usize,
+    /// How many workspaces the sampler currently has usage figures for.
+    pub usage_available: usize,
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+pub struct VersionCount {
+    pub version: String,
+    pub count: usize,
+}
+
+/// GET /api/dashboard
+pub async fn overview(
+    State(state): State<AppState>,
+    caller: AuthUser,
+) -> Result<Json<DashboardResponse>, AppError> {
+    caller.require("dashboard.read")?;
+
+    let snapshot = state.metrics.snapshot();
+    let cfg = workspaces::settings(&state.db).await?;
+    let users = crate::service::list(&state.db).await?;
+    let rows = workspace::Entity::find().all(&state.db).await?;
+
+    let mut items = Vec::with_capacity(users.len());
+    for user in users {
+        let row = rows.iter().find(|r| r.user_id == user.id);
+        let effective_version = row
+            .and_then(|r| workspaces::effective_version(&cfg, r))
+            .or_else(|| cfg.default_version.clone());
+        let provisioning = effective_version
+            .as_ref()
+            .and_then(|v| {
+                let image = render_image(&cfg.image_template, v);
+                state
+                    .provisioning
+                    .state(&image)
+                    .or_else(|| state.provisioning.state(&binary_key(v)))
+            })
+            .map(|(message, failed)| ProvisioningInfo { message, failed });
+        let runtime = attributed_runtime(row, snapshot.runtime(user.id));
+        items.push(DashboardWorkspace {
+            user_id: user.id,
+            username: user.username,
+            status: match (row, snapshot.sampled_at) {
+                // No intent row: the workspace was never used, and no sample
+                // is needed to know that.
+                (None, _) => "not_created",
+                // Nothing sampled yet, so the runtime state is genuinely not
+                // known; claiming "not created" here would be a guess.
+                (Some(_), None) => "unknown",
+                (Some(_), Some(_)) => runtime_status(runtime),
+            },
+            running_version: runtime.and_then(|r| r.version.clone()),
+            effective_version,
+            last_active_at: row.and_then(|r| r.last_active_at),
+            provisioning,
+        });
+    }
+
+    let (usage_supported, usage) = match snapshot.usage.as_ref() {
+        Some(UsageReport::Sampled(rows)) => (true, rows.clone()),
+        Some(UsageReport::Unsupported) => (false, Vec::new()),
+        None => (true, Vec::new()),
+    };
+
+    Ok(Json(DashboardResponse {
+        sampled_at: snapshot.sampled_at,
+        stale: snapshot.stale(),
+        errors: snapshot.errors.clone(),
+        system: snapshot.system.clone(),
+        summary: summarize(&items, &usage),
+        versions: version_counts(&items),
+        usage_supported,
+        usage,
+        workspaces: items,
+    }))
+}
+
+/// The runtime state belonging to a user, which is none at all unless they
+/// have an intent row.
+///
+/// A container can outlive the row that created it: a reset database, a
+/// hand-removed row. It is not that user's workspace, and consulting it anyway
+/// reported the orphan's version beside a `not_created` status. Status and
+/// version have to come from one decision, so both go through here.
+fn attributed_runtime<'a>(
+    row: Option<&workspace::Model>,
+    runtime: Option<&'a WorkspaceRuntime>,
+) -> Option<&'a WorkspaceRuntime> {
+    row.and(runtime)
+}
+
+fn summarize(items: &[DashboardWorkspace], usage: &[WorkspaceUsage]) -> Summary {
+    let mut summary = Summary {
+        total_users: items.len(),
+        usage_available: usage.len(),
+        ..Summary::default()
+    };
+    for item in items {
+        match item.status {
+            "running" => summary.running += 1,
+            "stopped" => summary.stopped += 1,
+            "not_created" => summary.not_created += 1,
+            _ => summary.unknown += 1,
+        }
+        if item.provisioning.is_some() {
+            summary.provisioning += 1;
+        }
+    }
+    summary
+}
+
+/// How many users sit on each effective version, most-used first, so a
+/// half-finished rollout is visible at a glance. Users with no version
+/// configured are not a version and are left out.
+fn version_counts(items: &[DashboardWorkspace]) -> Vec<VersionCount> {
+    let mut counts: Vec<VersionCount> = Vec::new();
+    for version in items.iter().filter_map(|i| i.effective_version.as_deref()) {
+        match counts.iter_mut().find(|c| c.version == version) {
+            Some(existing) => existing.count += 1,
+            None => counts.push(VersionCount {
+                version: version.to_string(),
+                count: 1,
+            }),
+        }
+    }
+    // Version as the tiebreaker so equal counts do not reorder between polls
+    // and make the widget flicker.
+    counts.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| a.version.cmp(&b.version))
+    });
+    counts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace(status: &'static str, version: Option<&str>) -> DashboardWorkspace {
+        DashboardWorkspace {
+            user_id: 1,
+            username: "u".to_string(),
+            status,
+            effective_version: version.map(String::from),
+            running_version: None,
+            last_active_at: None,
+            provisioning: None,
+        }
+    }
+
+    #[test]
+    fn the_summary_counts_every_status() {
+        let items = vec![
+            workspace("running", Some("v1")),
+            workspace("running", Some("v1")),
+            workspace("stopped", Some("v1")),
+            workspace("not_created", None),
+            workspace("unknown", Some("v2")),
+        ];
+        let usage = vec![WorkspaceUsage {
+            user_id: 1,
+            cpu_percent: 1.0,
+            memory_bytes: 2,
+            memory_limit_bytes: None,
+        }];
+        assert_eq!(
+            summarize(&items, &usage),
+            Summary {
+                total_users: 5,
+                running: 2,
+                stopped: 1,
+                not_created: 1,
+                unknown: 1,
+                provisioning: 0,
+                usage_available: 1,
+            }
+        );
+    }
+
+    /// Provisioning is a state a workspace is in *besides* its runtime status,
+    /// so it is counted separately rather than replacing one of the others.
+    #[test]
+    fn provisioning_is_counted_without_hiding_a_status() {
+        let mut item = workspace("not_created", Some("v1"));
+        item.provisioning = Some(ProvisioningInfo {
+            message: "pulling".to_string(),
+            failed: false,
+        });
+        let summary = summarize(&[item], &[]);
+        assert_eq!(summary.provisioning, 1);
+        assert_eq!(summary.not_created, 1);
+        assert_eq!(summary.total_users, 1);
+    }
+
+    /// Caught by a smoke test against a machine holding a container from an
+    /// earlier database: the dashboard printed `not_created` beside
+    /// `running_version: main-20260804`.
+    #[test]
+    fn a_runtime_without_an_intent_row_is_not_adopted() {
+        let runtime = WorkspaceRuntime {
+            user_id: 1,
+            running: true,
+            version: Some("main-20260804".to_string()),
+        };
+
+        let orphan = attributed_runtime(None, Some(&runtime));
+        assert!(orphan.is_none());
+        // Both fields go through the same decision, so neither can leak the
+        // orphan's state on its own.
+        assert_eq!(runtime_status(orphan), "not_created");
+        assert_eq!(orphan.and_then(|r| r.version.clone()), None);
+
+        let row = workspace::Model {
+            user_id: 1,
+            pinned_version: None,
+            last_active_at: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            bundle_token: None,
+        };
+        let owned = attributed_runtime(Some(&row), Some(&runtime));
+        assert_eq!(runtime_status(owned), "running");
+        assert_eq!(
+            owned.and_then(|r| r.version.clone()),
+            Some("main-20260804".to_string())
+        );
+    }
+
+    #[test]
+    fn version_counts_are_ordered_and_stable() {
+        let items = vec![
+            workspace("running", Some("v2")),
+            workspace("running", Some("v1")),
+            workspace("running", Some("v1")),
+            // No version configured is not a version.
+            workspace("not_created", None),
+        ];
+        assert_eq!(
+            version_counts(&items),
+            vec![
+                VersionCount {
+                    version: "v1".to_string(),
+                    count: 2
+                },
+                VersionCount {
+                    version: "v2".to_string(),
+                    count: 1
+                },
+            ]
+        );
+
+        // Equal counts order by version, so a poll cannot reshuffle the widget.
+        let tied = vec![
+            workspace("running", Some("v2")),
+            workspace("running", Some("v1")),
+        ];
+        assert_eq!(
+            version_counts(&tied)
+                .iter()
+                .map(|c| c.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["v1", "v2"]
+        );
+        assert!(version_counts(&[]).is_empty());
+    }
+}

--- a/api/src/handlers/dashboard.rs
+++ b/api/src/handlers/dashboard.rs
@@ -6,13 +6,14 @@
 //! or how many admins are watching.
 
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::Json;
 use chrono::{DateTime, Utc};
-use sea_orm::EntityTrait;
-use serde::Serialize;
+use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+use serde::{Deserialize, Serialize};
 
 use crate::auth::AuthUser;
-use crate::entities::workspace;
+use crate::entities::{dashboard_layout, workspace};
 use crate::error::AppError;
 use crate::handlers::workspaces::{runtime_status, ProvisioningInfo};
 use crate::metrics::SystemUsage;
@@ -145,6 +146,151 @@ pub async fn overview(
         usage,
         workspaces: items,
     }))
+}
+
+/// The one layout shape this build understands. Bumped only on a breaking
+/// change; a stored row at any other version is ignored and the caller gets
+/// the catalog defaults, which is why old rows can simply be left in place.
+const LAYOUT_SCHEMA_VERSION: u32 = 1;
+/// Enough for every widget the catalog is ever likely to hold, and small
+/// enough that a row cannot be used as storage.
+const MAX_LAYOUT_ITEMS: usize = 32;
+/// Applies to the serialized form, checked after parsing so the limit is on
+/// what actually gets stored.
+const MAX_LAYOUT_BYTES: usize = 8 * 1024;
+/// The grid width the frontend lays out against.
+const LAYOUT_COLUMNS: u32 = 12;
+
+/// A saved widget arrangement.
+///
+/// Validated rather than stored opaquely. Only its own author reads it back, so
+/// this is not a breach vector; what it prevents is a caller persisting a
+/// payload that breaks their dashboard on every load, or using the row as
+/// unbounded storage. `deny_unknown_fields` keeps a future field from being
+/// silently accepted by an older build that would then drop it on the next
+/// save.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DashboardLayout {
+    pub schema_version: u32,
+    pub items: Vec<LayoutItem>,
+    /// Widgets the user turned off. Kept separate from `items` so hiding one
+    /// and re-showing it does not lose where it used to sit.
+    #[serde(default)]
+    pub hidden: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LayoutItem {
+    pub id: String,
+    pub x: u32,
+    pub y: u32,
+    pub w: u32,
+    pub h: u32,
+}
+
+/// Widget ids come from the frontend catalog and are compared as strings, so
+/// the charset is pinned rather than left to whatever a caller sends.
+fn valid_widget_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id.starts_with(|c: char| c.is_ascii_lowercase())
+        && id
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// Structural checks only. Geometry is clamped by the frontend merge, which has
+/// to be defensive anyway; what matters here is that nothing unbounded or
+/// self-contradictory reaches the database.
+fn validate_layout(layout: &DashboardLayout) -> Result<(), AppError> {
+    if layout.schema_version != LAYOUT_SCHEMA_VERSION {
+        return Err(AppError::BadRequest("unsupported layout schema version"));
+    }
+    if layout.items.len() > MAX_LAYOUT_ITEMS || layout.hidden.len() > MAX_LAYOUT_ITEMS {
+        return Err(AppError::BadRequest("too many layout widgets"));
+    }
+    for item in &layout.items {
+        if !valid_widget_id(&item.id) {
+            return Err(AppError::BadRequest("invalid layout widget id"));
+        }
+        if item.w == 0 || item.h == 0 {
+            return Err(AppError::BadRequest("layout widgets need a size"));
+        }
+        // Saturating: `x + w` on the raw values overflows for an `x` near
+        // `u32::MAX`, which panics in debug and wraps past this check in
+        // release.
+        if item.x.saturating_add(item.w) > LAYOUT_COLUMNS {
+            return Err(AppError::BadRequest("layout widget exceeds the grid width"));
+        }
+    }
+    if layout.hidden.iter().any(|id| !valid_widget_id(id)) {
+        return Err(AppError::BadRequest("invalid layout widget id"));
+    }
+    // A duplicate id would make the merge nondeterministic: which of the two
+    // rectangles wins depends on iteration order.
+    let mut ids: Vec<&str> = layout.items.iter().map(|i| i.id.as_str()).collect();
+    ids.sort_unstable();
+    let count = ids.len();
+    ids.dedup();
+    if ids.len() != count {
+        return Err(AppError::BadRequest("duplicate layout widget id"));
+    }
+    Ok(())
+}
+
+/// GET /api/me/dashboard-layout: the caller's saved layout, or `null` when
+/// they have never customized it.
+pub async fn get_layout(
+    State(state): State<AppState>,
+    caller: AuthUser,
+) -> Result<Json<serde_json::Value>, AppError> {
+    caller.require("dashboard.read")?;
+    let row = dashboard_layout::Entity::find_by_id(caller.user.id)
+        .one(&state.db)
+        .await?;
+    // A row written by a newer build, or hand-edited into nonsense, must not
+    // break the dashboard: it reads as "no saved layout" and the next save
+    // replaces it.
+    let layout = row
+        .and_then(|r| serde_json::from_str::<DashboardLayout>(&r.layout).ok())
+        .filter(|l| validate_layout(l).is_ok());
+    Ok(Json(serde_json::json!({ "layout": layout })))
+}
+
+/// PUT /api/me/dashboard-layout
+pub async fn put_layout(
+    State(state): State<AppState>,
+    caller: AuthUser,
+    Json(layout): Json<DashboardLayout>,
+) -> Result<StatusCode, AppError> {
+    caller.require("dashboard.read")?;
+    validate_layout(&layout)?;
+
+    // Serialized from the parsed value, not echoed from the request body, so
+    // only the shape above is ever stored.
+    let encoded = serde_json::to_string(&layout)
+        .map_err(|_| AppError::BadRequest("layout could not be stored"))?;
+    if encoded.len() > MAX_LAYOUT_BYTES {
+        return Err(AppError::BadRequest("layout is too large"));
+    }
+
+    let model = dashboard_layout::ActiveModel {
+        user_id: Set(caller.user.id),
+        layout: Set(encoded),
+        updated_at: Set(Utc::now()),
+    };
+    if dashboard_layout::Entity::find_by_id(caller.user.id)
+        .one(&state.db)
+        .await?
+        .is_some()
+    {
+        model.update(&state.db).await?;
+    } else {
+        model.insert(&state.db).await?;
+    }
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// The runtime state belonging to a user, which is none at all unless they
@@ -297,6 +443,109 @@ mod tests {
             owned.and_then(|r| r.version.clone()),
             Some("main-20260804".to_string())
         );
+    }
+
+    fn layout(items: Vec<(&str, u32, u32)>) -> DashboardLayout {
+        DashboardLayout {
+            schema_version: LAYOUT_SCHEMA_VERSION,
+            items: items
+                .into_iter()
+                .map(|(id, x, w)| LayoutItem {
+                    id: id.to_string(),
+                    x,
+                    y: 0,
+                    w,
+                    h: 3,
+                })
+                .collect(),
+            hidden: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_well_formed_layout_is_accepted() {
+        let mut ok = layout(vec![("system-usage", 0, 6), ("fleet-status", 6, 6)]);
+        assert!(validate_layout(&ok).is_ok());
+        ok.hidden = vec!["version-spread".to_string()];
+        assert!(validate_layout(&ok).is_ok());
+        // A widget may span the full grid, just not exceed it.
+        assert!(validate_layout(&layout(vec![("system-usage", 0, 12)])).is_ok());
+    }
+
+    #[test]
+    fn a_layout_from_another_schema_version_is_refused() {
+        let mut wrong = layout(vec![("system-usage", 0, 6)]);
+        wrong.schema_version = LAYOUT_SCHEMA_VERSION + 1;
+        assert!(validate_layout(&wrong).is_err());
+        wrong.schema_version = 0;
+        assert!(validate_layout(&wrong).is_err());
+    }
+
+    /// A saved row is only ever read back by its own author, so this is not
+    /// about a breach: it stops a caller persisting something that breaks
+    /// their own dashboard on every load, or using the row as storage.
+    #[test]
+    fn unbounded_and_self_contradictory_layouts_are_refused() {
+        let many: Vec<(&str, u32, u32)> = (0..MAX_LAYOUT_ITEMS + 1)
+            .map(|_| ("system-usage", 0, 1))
+            .collect();
+        assert!(validate_layout(&layout(many)).is_err());
+
+        let mut hidden = layout(vec![("system-usage", 0, 6)]);
+        hidden.hidden = (0..MAX_LAYOUT_ITEMS + 1).map(|_| "w".to_string()).collect();
+        assert!(validate_layout(&hidden).is_err());
+
+        // Two rectangles for one widget: which one wins would depend on
+        // iteration order.
+        assert!(validate_layout(&layout(vec![
+            ("system-usage", 0, 6),
+            ("system-usage", 6, 6)
+        ]))
+        .is_err());
+
+        // Off the grid, and zero-sized.
+        assert!(validate_layout(&layout(vec![("system-usage", 8, 6)])).is_err());
+        assert!(validate_layout(&layout(vec![("system-usage", 0, 0)])).is_err());
+
+        // Extreme coordinates must be rejected, not overflow the bounds check
+        // into passing it.
+        assert!(validate_layout(&layout(vec![("system-usage", u32::MAX, 1)])).is_err());
+        assert!(validate_layout(&layout(vec![("system-usage", 1, u32::MAX)])).is_err());
+        let mut tall = layout(vec![("system-usage", 0, 6)]);
+        tall.items[0].y = u32::MAX;
+        // A huge `y` only makes a very long page for its own author, so it is
+        // the frontend merge that clamps it; it must at least not panic here.
+        assert!(validate_layout(&tall).is_ok());
+    }
+
+    #[test]
+    fn widget_ids_are_restricted_to_the_catalog_charset() {
+        assert!(valid_widget_id("system-usage"));
+        assert!(valid_widget_id("w1"));
+        assert!(!valid_widget_id(""));
+        assert!(!valid_widget_id("System-Usage"));
+        assert!(!valid_widget_id("1widget"));
+        assert!(!valid_widget_id("-widget"));
+        assert!(!valid_widget_id("widget_name"));
+        assert!(!valid_widget_id("../../etc/passwd"));
+        assert!(!valid_widget_id(&"w".repeat(65)));
+
+        assert!(validate_layout(&layout(vec![("Bad Id", 0, 6)])).is_err());
+        let mut bad_hidden = layout(vec![("system-usage", 0, 6)]);
+        bad_hidden.hidden = vec!["Bad Id".to_string()];
+        assert!(validate_layout(&bad_hidden).is_err());
+    }
+
+    /// An older build must not silently accept and then drop a field a newer
+    /// one added, which is what turns a forward-compatible save into data loss.
+    #[test]
+    fn an_unknown_layout_field_is_refused_at_parse() {
+        let json = r#"{"schema_version":1,"items":[],"hidden":[],"columns":24}"#;
+        assert!(serde_json::from_str::<DashboardLayout>(json).is_err());
+        // `hidden` is genuinely optional, though.
+        let json = r#"{"schema_version":1,"items":[]}"#;
+        let parsed: DashboardLayout = serde_json::from_str(json).unwrap();
+        assert!(parsed.hidden.is_empty());
     }
 
     #[test]

--- a/api/src/handlers/mod.rs
+++ b/api/src/handlers/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_credentials;
 pub mod auth;
+pub mod dashboard;
 pub mod oidc;
 pub mod roles;
 pub mod settings;

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -9,7 +9,8 @@ use crate::auth::AuthUser;
 use crate::entities::{workspace, workspace_settings};
 use crate::error::AppError;
 use crate::orchestrator::{
-    binary_key, render_image, telemetry_policy_override, TelemetryPolicy, WorkspaceStatus,
+    binary_key, render_image, telemetry_policy_override, TelemetryPolicy, WorkspaceRuntime,
+    WorkspaceStatus,
 };
 use crate::proxy;
 use crate::state::AppState;
@@ -47,6 +48,50 @@ fn status_str(status: Result<WorkspaceStatus, impl std::fmt::Display>) -> &'stat
     }
 }
 
+/// How the fleet's runtime state was obtained for one listing.
+enum Fleet {
+    /// One batch call answered for everyone. A user missing from the map has
+    /// no runtime object.
+    Batched(std::collections::HashMap<i32, WorkspaceRuntime>),
+    /// The backend supports batching but the call failed. Reported as
+    /// `unknown` rather than retried per user: whatever broke the batch call
+    /// (a stopped daemon, usually) would break N more of them.
+    Unavailable,
+    /// The backend has no batch path, so fall back to one call per user.
+    PerUser,
+}
+
+impl Fleet {
+    async fn load(state: &AppState) -> Self {
+        match state.orchestrator.statuses().await {
+            Ok(Some(rows)) => Fleet::Batched(rows.into_iter().map(|r| (r.user_id, r)).collect()),
+            Ok(None) => Fleet::PerUser,
+            Err(e) => {
+                tracing::warn!("batch workspace status check failed: {e}");
+                Fleet::Unavailable
+            }
+        }
+    }
+
+    async fn status_of(&self, state: &AppState, user_id: i32) -> &'static str {
+        match self {
+            Fleet::Batched(map) => runtime_status(map.get(&user_id)),
+            Fleet::Unavailable => "unknown",
+            Fleet::PerUser => status_str(state.orchestrator.status(user_id).await),
+        }
+    }
+}
+
+/// A batch runtime row as a status string. Absent means no runtime object
+/// exists, which is the same thing `status()` reports as `NotCreated`.
+fn runtime_status(runtime: Option<&WorkspaceRuntime>) -> &'static str {
+    match runtime {
+        Some(rt) if rt.running => "running",
+        Some(_) => "stopped",
+        None => "not_created",
+    }
+}
+
 /// GET /api/workspaces: every user with their workspace state.
 pub async fn list(
     State(state): State<AppState>,
@@ -56,6 +101,9 @@ pub async fn list(
     let cfg = workspaces::settings(&state.db).await?;
     let users = crate::service::list(&state.db).await?;
     let rows = workspace::Entity::find().all(&state.db).await?;
+    // One round-trip for the whole fleet where the backend can manage it,
+    // instead of a shell-out per user on a page that polls every 10 seconds.
+    let fleet = Fleet::load(&state).await;
 
     let mut items = Vec::with_capacity(users.len());
     for user in users {
@@ -78,7 +126,7 @@ pub async fn list(
         items.push(WorkspaceItem {
             user_id: user.id,
             status: match row {
-                Some(_) => status_str(state.orchestrator.status(user.id).await),
+                Some(_) => fleet.status_of(&state, user.id).await,
                 // No intent row: never used, skip the runtime round-trip.
                 None => "not_created",
             },
@@ -600,5 +648,35 @@ mod tests {
         // Including on the very first save, when there is no row yet.
         assert!(policy_to_store("force_maybe", None).is_err());
         assert!(policy_to_store("", None).is_err());
+    }
+
+    #[test]
+    fn a_batch_row_maps_to_the_same_strings_as_a_per_user_check() {
+        let running = WorkspaceRuntime {
+            user_id: 1,
+            running: true,
+            version: None,
+        };
+        let stopped = WorkspaceRuntime {
+            user_id: 1,
+            running: false,
+            version: None,
+        };
+        assert_eq!(runtime_status(Some(&running)), "running");
+        assert_eq!(runtime_status(Some(&stopped)), "stopped");
+        // Absent from the batch listing means no container exists, which is
+        // exactly what `status()` reports as NotCreated.
+        assert_eq!(runtime_status(None), "not_created");
+
+        // The two paths have to agree, or a user's status would change purely
+        // because their backend gained a batch implementation.
+        let ok: Result<WorkspaceStatus, String> = Ok(WorkspaceStatus::Running {
+            addr: "127.0.0.1:1".to_string(),
+        });
+        assert_eq!(status_str(ok), runtime_status(Some(&running)));
+        let ok: Result<WorkspaceStatus, String> = Ok(WorkspaceStatus::Stopped);
+        assert_eq!(status_str(ok), runtime_status(Some(&stopped)));
+        let ok: Result<WorkspaceStatus, String> = Ok(WorkspaceStatus::NotCreated);
+        assert_eq!(status_str(ok), runtime_status(None));
     }
 }

--- a/api/src/handlers/workspaces.rs
+++ b/api/src/handlers/workspaces.rs
@@ -84,7 +84,7 @@ impl Fleet {
 
 /// A batch runtime row as a status string. Absent means no runtime object
 /// exists, which is the same thing `status()` reports as `NotCreated`.
-fn runtime_status(runtime: Option<&WorkspaceRuntime>) -> &'static str {
+pub(crate) fn runtime_status(runtime: Option<&WorkspaceRuntime>) -> &'static str {
     match runtime {
         Some(rt) if rt.running => "running",
         Some(_) => "stopped",

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -9,6 +9,7 @@ mod error;
 mod git_ssh;
 mod handlers;
 mod mailer;
+mod metrics;
 mod migration;
 mod oidc;
 mod orchestrator;

--- a/api/src/metrics.rs
+++ b/api/src/metrics.rs
@@ -1,0 +1,500 @@
+//! System metrics for the admin dashboard.
+//!
+//! Two rules shape this module, both learned from how easy these numbers are to
+//! misread:
+//!
+//! - Nothing here is called "host". CityHall commonly runs in a container next
+//!   to the very workspaces it reports on, so the figures describe the system
+//!   *visible to the CityHall process*, which may or may not be the docker
+//!   host. Every payload carries its [`MetricScope`] so the UI can say which.
+//! - A cgroup memory limit never overrides the system totals. Substituting it
+//!   would produce system-wide CPU beside container-local memory under one
+//!   label, which is worse than either number alone; it is reported as its own
+//!   block instead.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sysinfo::System;
+
+use sea_orm::EntityTrait;
+
+use crate::entities::workspace;
+use crate::orchestrator::{UsageReport, WorkspaceRuntime, WorkspaceStatus};
+use crate::state::AppState;
+
+/// How often the fleet is sampled. Matched to the dashboard's own poll so a
+/// viewer rarely sees the same numbers twice, and the load is the same three
+/// backend calls whether one admin is watching or ten.
+const SAMPLE_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Snapshots older than this are flagged in the UI: at three missed intervals
+/// the sampler is stuck rather than merely between ticks.
+const STALE_AFTER: Duration = Duration::from_secs(30);
+
+/// What the system figures actually describe.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricScope {
+    /// CityHall runs directly on the machine, so these are host figures.
+    Host,
+    /// CityHall runs in a container: the numbers are whatever its namespace
+    /// sees, which is usually the host's CPU and memory rather than its own.
+    CityHallContainer,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SystemUsage {
+    pub scope: MetricScope,
+    /// Percentage across all logical CPUs, so a fully busy 8-core box reads
+    /// 100, not 800.
+    pub cpu_percent: f32,
+    pub cpu_count: usize,
+    pub memory_used_bytes: u64,
+    pub memory_total_bytes: u64,
+    /// CityHall's own cgroup memory limit, when it has one that is actually
+    /// narrower than the system's. Never a substitute for the fields above.
+    pub cgroup_memory: Option<CgroupMemory>,
+    /// Only present when `SYSTEM_METRICS_DISK_PATH` names a filesystem that
+    /// could be resolved. There is no default: see [`disk_path`].
+    pub disk: Option<DiskUsage>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct CgroupMemory {
+    pub used_bytes: u64,
+    pub limit_bytes: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct DiskUsage {
+    /// The configured path that was asked about.
+    pub path: String,
+    /// The mount point actually holding it, which is often shorter than
+    /// `path` and is worth showing so an operator can tell the two apart.
+    pub mount_point: String,
+    pub used_bytes: u64,
+    pub total_bytes: u64,
+}
+
+/// Owns the long-lived `sysinfo::System`. CPU percentages are deltas between
+/// two refreshes, so the sampler has to outlive a single measurement; a
+/// per-request sampler would report either zero or nonsense.
+pub struct SystemSampler {
+    system: System,
+    scope: MetricScope,
+    disk_path: Option<PathBuf>,
+}
+
+impl SystemSampler {
+    pub fn from_env() -> Self {
+        SystemSampler {
+            system: System::new(),
+            scope: scope(),
+            disk_path: disk_path(),
+        }
+    }
+
+    /// Prime the CPU delta. `global_cpu_usage` compares against the previous
+    /// refresh, so without this the first published snapshot reports 0%.
+    pub async fn prime(&mut self) {
+        self.system.refresh_cpu_usage();
+        tokio::time::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL).await;
+    }
+
+    pub fn sample(&mut self) -> SystemUsage {
+        self.system.refresh_cpu_usage();
+        self.system.refresh_memory();
+
+        let memory_total_bytes = self.system.total_memory();
+        SystemUsage {
+            scope: self.scope,
+            cpu_percent: self.system.global_cpu_usage(),
+            cpu_count: self.system.cpus().len(),
+            memory_used_bytes: self.system.used_memory(),
+            memory_total_bytes,
+            cgroup_memory: cgroup_memory(self.system.cgroup_limits(), memory_total_bytes),
+            disk: self
+                .disk_path
+                .as_deref()
+                .and_then(|path| disk_usage(&sysinfo::Disks::new_with_refreshed_list(), path)),
+        }
+    }
+}
+
+/// Everything the dashboard needs about the runtime, as of one moment.
+///
+/// Sources fail independently. A tick that cannot reach the daemon keeps the
+/// previous values for whatever it could not refresh and records why, because
+/// blanking a dashboard is a worse answer than showing numbers that are ten
+/// seconds old and labelled as such.
+#[derive(Clone, Debug, Default)]
+pub struct Snapshot {
+    /// `None` until the first tick completes, which the UI shows as
+    /// "collecting" rather than as an absence of workspaces.
+    pub sampled_at: Option<DateTime<Utc>>,
+    pub runtimes: Vec<WorkspaceRuntime>,
+    pub usage: Option<UsageReport>,
+    pub system: Option<SystemUsage>,
+    /// What failed on the most recent tick, for display. Empty is the happy
+    /// path.
+    pub errors: Vec<String>,
+}
+
+impl Snapshot {
+    pub fn runtime(&self, user_id: i32) -> Option<&WorkspaceRuntime> {
+        self.runtimes.iter().find(|r| r.user_id == user_id)
+    }
+
+    /// Whether the sampler looks stuck rather than simply between ticks.
+    pub fn stale(&self) -> bool {
+        match self.sampled_at {
+            None => true,
+            Some(at) => (Utc::now() - at)
+                .to_std()
+                .map(|age| age > STALE_AFTER)
+                .unwrap_or(false),
+        }
+    }
+}
+
+/// The published snapshot. Readers clone an `Arc`, so a dashboard request never
+/// waits on the sampler and never touches the container runtime.
+#[derive(Default)]
+pub struct Metrics {
+    snapshot: RwLock<Arc<Snapshot>>,
+}
+
+impl Metrics {
+    pub fn snapshot(&self) -> Arc<Snapshot> {
+        self.snapshot.read().unwrap().clone()
+    }
+
+    fn publish(&self, snapshot: Snapshot) {
+        *self.snapshot.write().unwrap() = Arc::new(snapshot);
+    }
+}
+
+/// Background loop owning every backend read the dashboard displays.
+///
+/// The dashboard deliberately does no collection of its own: doing it per
+/// request meant one process spawn per user per poll per watching admin, which
+/// is how a control plane ends up load-testing its own container runtime.
+pub async fn sampler(state: AppState) {
+    let mut system = SystemSampler::from_env();
+    // Without a primed delta the first published CPU figure is always 0%.
+    system.prime().await;
+
+    let mut interval = tokio::time::interval(SAMPLE_INTERVAL);
+    // Delay, not Burst: a tick that overran must not be followed by a queued
+    // pile of catch-up samples hammering the daemon.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        interval.tick().await;
+        let snapshot = sample_once(&state, &mut system).await;
+        state.metrics.publish(snapshot);
+    }
+}
+
+async fn sample_once(state: &AppState, system: &mut SystemSampler) -> Snapshot {
+    let previous = state.metrics.snapshot();
+    let mut errors = Vec::new();
+
+    let runtimes = match statuses(state).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            errors.push(format!("workspace status: {e}"));
+            previous.runtimes.clone()
+        }
+    };
+
+    let usage = match state.orchestrator.usage().await {
+        Ok(report) => Some(report),
+        Err(e) => {
+            errors.push(format!("workspace usage: {e}"));
+            previous.usage.clone()
+        }
+    };
+
+    Snapshot {
+        sampled_at: Some(Utc::now()),
+        runtimes,
+        usage,
+        system: Some(system.sample()),
+        errors,
+    }
+}
+
+/// Fleet runtime state, batched when the backend can and per-user when it
+/// cannot. The fallback lives here rather than in the request path so the
+/// dashboard costs the same on every backend.
+async fn statuses(state: &AppState) -> Result<Vec<WorkspaceRuntime>, String> {
+    if let Some(rows) = state
+        .orchestrator
+        .statuses()
+        .await
+        .map_err(|e| e.to_string())?
+    {
+        return Ok(rows);
+    }
+
+    let rows = workspace::Entity::find()
+        .all(&state.db)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut runtimes = Vec::with_capacity(rows.len());
+    for row in rows {
+        // A per-user failure is that workspace's problem, not the fleet's: it
+        // simply has no runtime row and reads as unknown.
+        if let Ok(status) = state.orchestrator.status(row.user_id).await {
+            runtimes.push(WorkspaceRuntime {
+                user_id: row.user_id,
+                running: matches!(status, WorkspaceStatus::Running { .. }),
+                // This path has no version to report; the effective version
+                // from the database covers the display.
+                version: None,
+            });
+        }
+    }
+    Ok(runtimes)
+}
+
+/// `SYSTEM_METRICS_SCOPE` wins when set; otherwise detect, so the common
+/// compose deployment is labelled correctly without the operator doing
+/// anything. Detection is a heuristic, which is exactly why the override
+/// exists.
+fn scope() -> MetricScope {
+    match parse_scope(std::env::var("SYSTEM_METRICS_SCOPE").ok().as_deref()) {
+        Some(scope) => scope,
+        None => detect_scope(),
+    }
+}
+
+fn parse_scope(value: Option<&str>) -> Option<MetricScope> {
+    match value.map(str::trim).unwrap_or_default() {
+        "host" => Some(MetricScope::Host),
+        "container" => Some(MetricScope::CityHallContainer),
+        other => {
+            if !other.is_empty() {
+                tracing::warn!(
+                    "ignoring SYSTEM_METRICS_SCOPE '{other}' (expected host or container)"
+                );
+            }
+            None
+        }
+    }
+}
+
+/// `/.dockerenv` covers docker and compose; PID 1's cgroup path covers
+/// podman, containerd, and kubernetes. Neither is authoritative, hence the
+/// override above.
+fn detect_scope() -> MetricScope {
+    if Path::new("/.dockerenv").exists() {
+        return MetricScope::CityHallContainer;
+    }
+    match std::fs::read_to_string("/proc/1/cgroup") {
+        Ok(cgroup) if containerized_cgroup(&cgroup) => MetricScope::CityHallContainer,
+        _ => MetricScope::Host,
+    }
+}
+
+fn containerized_cgroup(cgroup: &str) -> bool {
+    ["docker", "kubepods", "containerd", "libpod", "lxc"]
+        .iter()
+        .any(|marker| cgroup.contains(marker))
+}
+
+/// The filesystem to report, or `None` to omit disk entirely.
+///
+/// There is deliberately no default. Under an overlay filesystem `/` measures
+/// the container's own image layers, not the volumes workspaces live on, so a
+/// default would put a confidently wrong number on the dashboard. Unset means
+/// the widget disappears, which is honest.
+fn disk_path() -> Option<PathBuf> {
+    let raw = std::env::var("SYSTEM_METRICS_DISK_PATH").unwrap_or_default();
+    let trimmed = raw.trim();
+    (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+}
+
+/// A cgroup limit is only worth showing when it is actually narrower than the
+/// system's memory. An unconstrained cgroup on Linux reports the host total,
+/// and echoing that back as a second identical block just invites the reader
+/// to think one of the two numbers is wrong.
+fn cgroup_memory(limits: Option<sysinfo::CGroupLimits>, system_total: u64) -> Option<CgroupMemory> {
+    let limits = limits?;
+    (limits.total_memory > 0 && limits.total_memory < system_total).then(|| CgroupMemory {
+        used_bytes: limits.total_memory.saturating_sub(limits.free_memory),
+        limit_bytes: limits.total_memory,
+    })
+}
+
+fn disk_usage(disks: &sysinfo::Disks, path: &Path) -> Option<DiskUsage> {
+    let mounts: Vec<(&Path, u64, u64)> = disks
+        .list()
+        .iter()
+        .map(|d| (d.mount_point(), d.total_space(), d.available_space()))
+        .collect();
+    select_disk(&mounts, path)
+}
+
+/// The mount point holding `path`: the longest one that is a prefix of it.
+///
+/// Longest wins because mount points nest. With `/` and `/var/lib/docker` both
+/// mounted, a path under the latter has to resolve to it, and picking the
+/// first prefix match would report the wrong filesystem's free space.
+fn select_disk(mounts: &[(&Path, u64, u64)], path: &Path) -> Option<DiskUsage> {
+    mounts
+        .iter()
+        .filter(|(mount, _, _)| path.starts_with(mount))
+        .max_by_key(|(mount, _, _)| mount.as_os_str().len())
+        .map(|(mount, total, available)| DiskUsage {
+            path: path.display().to_string(),
+            mount_point: mount.display().to_string(),
+            used_bytes: total.saturating_sub(*available),
+            total_bytes: *total,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_explicit_scope_overrides_detection() {
+        assert_eq!(parse_scope(Some("host")), Some(MetricScope::Host));
+        assert_eq!(
+            parse_scope(Some(" container ")),
+            Some(MetricScope::CityHallContainer)
+        );
+        // Unset or unparseable falls through to detection rather than
+        // guessing, so a typo cannot silently mislabel every metric.
+        assert_eq!(parse_scope(None), None);
+        assert_eq!(parse_scope(Some("")), None);
+        assert_eq!(parse_scope(Some("HOST")), None);
+        assert_eq!(parse_scope(Some("yes")), None);
+    }
+
+    #[test]
+    fn container_runtimes_are_recognized_in_a_cgroup_path() {
+        assert!(containerized_cgroup(
+            "0::/docker/3f2a1b0c9d8e7f6a5b4c3d2e1f0a9b8c"
+        ));
+        assert!(containerized_cgroup("0::/kubepods/besteffort/pod1234"));
+        assert!(containerized_cgroup("0::/libpod-abc.scope"));
+        // A bare systemd host slice is not a container.
+        assert!(!containerized_cgroup("0::/init.scope"));
+        assert!(!containerized_cgroup("0::/user.slice/user-1000.slice"));
+    }
+
+    #[test]
+    fn a_cgroup_limit_is_reported_only_when_narrower_than_the_system() {
+        let limits = |total, free| {
+            Some(sysinfo::CGroupLimits {
+                total_memory: total,
+                free_memory: free,
+                free_swap: 0,
+                rss: 0,
+            })
+        };
+
+        // A real container limit: reported, with used derived from free.
+        assert_eq!(
+            cgroup_memory(limits(1_000, 250), 8_000),
+            Some(CgroupMemory {
+                used_bytes: 750,
+                limit_bytes: 1_000
+            })
+        );
+
+        // An unconstrained cgroup reports the host total. Echoing that back as
+        // a second, identical memory block reads like one of the two numbers
+        // is broken.
+        assert_eq!(cgroup_memory(limits(8_000, 4_000), 8_000), None);
+        assert_eq!(cgroup_memory(limits(9_000, 4_000), 8_000), None);
+        assert_eq!(cgroup_memory(limits(0, 0), 8_000), None);
+        // Not Linux: nothing to report.
+        assert_eq!(cgroup_memory(None, 8_000), None);
+    }
+
+    #[test]
+    fn the_longest_matching_mount_holds_the_path() {
+        let root = Path::new("/");
+        let docker = Path::new("/var/lib/docker");
+        let mounts = [(root, 100, 40), (docker, 1_000, 100)];
+
+        // Nested mounts: the workspace volume path resolves to the volume
+        // filesystem, not to the root one that also prefixes it.
+        let picked = select_disk(&mounts, Path::new("/var/lib/docker/volumes/x")).unwrap();
+        assert_eq!(picked.mount_point, "/var/lib/docker");
+        assert_eq!(picked.total_bytes, 1_000);
+        assert_eq!(picked.used_bytes, 900);
+        // The configured path is echoed back so an operator can tell which
+        // path produced which mount.
+        assert_eq!(picked.path, "/var/lib/docker/volumes/x");
+
+        let picked = select_disk(&mounts, Path::new("/srv/data")).unwrap();
+        assert_eq!(picked.mount_point, "/");
+        assert_eq!(picked.used_bytes, 60);
+
+        // Order must not decide the winner.
+        let reversed = [(docker, 1_000, 100), (root, 100, 40)];
+        assert_eq!(
+            select_disk(&reversed, Path::new("/var/lib/docker/volumes/x"))
+                .unwrap()
+                .mount_point,
+            "/var/lib/docker"
+        );
+    }
+
+    #[test]
+    fn an_unresolvable_path_yields_no_disk() {
+        // Nothing mounted at all, and a relative path that prefixes nothing:
+        // omitted rather than defaulted to some arbitrary filesystem.
+        assert!(select_disk(&[], Path::new("/anything")).is_none());
+        let mounts = [(Path::new("/mnt/data"), 10, 5)];
+        assert!(select_disk(&mounts, Path::new("/other")).is_none());
+    }
+
+    #[test]
+    fn disk_is_omitted_unless_configured() {
+        // The guard the whole "no default mount" decision rests on.
+        assert!(disk_path_from("").is_none());
+        assert!(disk_path_from("   ").is_none());
+        assert_eq!(
+            disk_path_from("/var/lib/docker"),
+            Some(PathBuf::from("/var/lib/docker"))
+        );
+    }
+
+    /// `disk_path` reads the environment, which is process-global and so
+    /// unsafe to mutate from a test that runs beside others. This mirrors its
+    /// trimming rules on an injected value.
+    fn disk_path_from(raw: &str) -> Option<PathBuf> {
+        let trimmed = raw.trim();
+        (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+    }
+
+    /// The sampler must produce plausible figures on the machine running the
+    /// tests, whatever that machine is. Guards against a refresh call being
+    /// dropped, which would silently report zeros forever.
+    #[test]
+    fn a_sample_reports_real_memory_and_cpu_bounds() {
+        let mut sampler = SystemSampler {
+            system: System::new(),
+            scope: MetricScope::Host,
+            disk_path: None,
+        };
+        let usage = sampler.sample();
+        assert!(usage.memory_total_bytes > 0);
+        assert!(usage.memory_used_bytes <= usage.memory_total_bytes);
+        assert!(usage.cpu_count > 0);
+        // Averaged across cores, so it cannot exceed 100 however busy the box
+        // is. The first sample has no delta to compare against, hence 0.0 is
+        // legitimate here.
+        assert!((0.0..=100.0).contains(&usage.cpu_percent));
+        assert!(usage.disk.is_none());
+    }
+}

--- a/api/src/migration/m0017_create_dashboard_layouts.rs
+++ b/api/src/migration/m0017_create_dashboard_layouts.rs
@@ -1,0 +1,60 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::schema::*;
+
+use super::m0001_create_users::Users;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // One dashboard layout per user, so a customized dashboard follows the
+        // admin to another browser instead of living in that browser's
+        // localStorage (#12).
+        //
+        // The layout is stored as JSON text rather than as columns: it is a
+        // list of widget rectangles whose shape belongs to the frontend
+        // catalog, and modelling grid coordinates relationally would buy
+        // nothing while making every new widget a migration. The handler still
+        // validates it against a typed schema before it lands here, so the
+        // column holds a known shape and not arbitrary caller bytes.
+        //
+        // Its own table rather than a general `user_preferences(namespace,
+        // value)` one: there is no second preference today, and a generic
+        // table needs a server-side namespace allowlist to stop a caller
+        // writing unbounded rows, which is this table with more indirection.
+        manager
+            .create_table(
+                Table::create()
+                    .table(DashboardLayouts::Table)
+                    .if_not_exists()
+                    .col(integer(DashboardLayouts::UserId).primary_key())
+                    .col(text(DashboardLayouts::Layout))
+                    .col(timestamp_with_time_zone(DashboardLayouts::UpdatedAt))
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(DashboardLayouts::Table, DashboardLayouts::UserId)
+                            .to(Users::Table, Users::Id)
+                            // A deleted user's layout is meaningless.
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(DashboardLayouts::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+pub enum DashboardLayouts {
+    Table,
+    UserId,
+    Layout,
+    UpdatedAt,
+}

--- a/api/src/migration/mod.rs
+++ b/api/src/migration/mod.rs
@@ -16,6 +16,7 @@ mod m0013_create_agent_credentials;
 mod m0014_create_git_ssh_keys;
 mod m0015_add_workspace_telemetry_policy;
 mod m0016_add_agents_to_workspace_settings;
+mod m0017_create_dashboard_layouts;
 
 pub struct Migrator;
 
@@ -39,6 +40,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0014_create_git_ssh_keys::Migration),
             Box::new(m0015_add_workspace_telemetry_policy::Migration),
             Box::new(m0016_add_agents_to_workspace_settings::Migration),
+            Box::new(m0017_create_dashboard_layouts::Migration),
         ]
     }
 }

--- a/api/src/orchestrator/docker.rs
+++ b/api/src/orchestrator/docker.rs
@@ -22,7 +22,8 @@ use tokio::process::Command;
 
 use super::{
     proxy_allowed_host, proxy_allowed_origin, wait_ready, Begin, Orchestrator, OrchestratorError,
-    ProvisioningRegistry, TelemetryPolicy, WorkspaceSpec, WorkspaceStatus,
+    ProvisioningRegistry, TelemetryPolicy, UsageReport, WorkspaceRuntime, WorkspaceSpec,
+    WorkspaceStatus, WorkspaceUsage,
 };
 
 /// Port aoe serves on inside the workspace container.
@@ -33,6 +34,15 @@ const AOE_DATA_DIR: &str = "/home/aoe/.config/agent-of-empires";
 const CLI_TIMEOUT: Duration = Duration::from_secs(60);
 /// Image pulls and first builds legitimately take minutes.
 const PROVISION_TIMEOUT: Duration = Duration::from_secs(600);
+/// Budget for the dashboard's batch reads. Short on purpose: these run on a
+/// sampling interval, and a stuck daemon should leave the last good snapshot in
+/// place rather than pin a sampler tick for a minute.
+const BATCH_TIMEOUT: Duration = Duration::from_secs(10);
+/// Marks every container CityHall created, and the only thing that makes a
+/// container ours.
+const MANAGED_FILTER: &str = "label=cityhall.managed=true";
+const USER_ID_LABEL: &str = "cityhall.user_id";
+const VERSION_LABEL: &str = "cityhall.workspace.version";
 
 /// The reference workspace image build, embedded so a running CityHall can
 /// build missing images without a repo checkout. It needs no build context
@@ -72,9 +82,20 @@ impl DockerCliOrchestrator {
     /// reported as `Ok(None)` so callers can treat missing objects as state,
     /// not failure.
     async fn run(&self, args: &[&str]) -> Result<Option<String>, OrchestratorError> {
+        self.run_timeout(args, CLI_TIMEOUT).await
+    }
+
+    /// [`Self::run`] with an explicit budget, for the dashboard's batch reads:
+    /// they run on a poll and must fail fast, where a lifecycle command can
+    /// legitimately sit for the full minute.
+    async fn run_timeout(
+        &self,
+        args: &[&str],
+        timeout: Duration,
+    ) -> Result<Option<String>, OrchestratorError> {
         let mut cmd = Command::new(&self.cli);
         cmd.args(args).kill_on_drop(true);
-        let output = tokio::time::timeout(CLI_TIMEOUT, cmd.output())
+        let output = tokio::time::timeout(timeout, cmd.output())
             .await
             .map_err(|_| {
                 OrchestratorError::Runtime(format!("{} {} timed out", self.cli, args.join(" ")))
@@ -596,6 +617,227 @@ impl Orchestrator for DockerCliOrchestrator {
             Some(_) => Ok(WorkspaceStatus::Stopped),
         }
     }
+
+    /// One `docker ps` for the whole fleet, replacing a `container inspect` per
+    /// user.
+    async fn statuses(&self) -> Result<Option<Vec<WorkspaceRuntime>>, OrchestratorError> {
+        let out = self
+            .run_timeout(
+                &[
+                    "ps",
+                    "-a",
+                    "--filter",
+                    MANAGED_FILTER,
+                    "--format",
+                    "{{json .}}",
+                ],
+                BATCH_TIMEOUT,
+            )
+            .await?
+            .unwrap_or_default();
+        Ok(Some(parse_ps(&out)))
+    }
+
+    async fn usage(&self) -> Result<UsageReport, OrchestratorError> {
+        // Listed first so `stats` is handed only our containers. `docker stats`
+        // takes no `--filter`, and left unqualified it makes the daemon sample
+        // every unrelated workload on the host.
+        let ids = self
+            .run_timeout(
+                &[
+                    "ps",
+                    "-q",
+                    "--filter",
+                    MANAGED_FILTER,
+                    "--filter",
+                    "status=running",
+                ],
+                BATCH_TIMEOUT,
+            )
+            .await?
+            .unwrap_or_default();
+        let ids: Vec<&str> = ids
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .collect();
+        if ids.is_empty() {
+            return Ok(UsageReport::Sampled(Vec::new()));
+        }
+
+        let mut args = vec!["stats", "--no-stream", "--format", "{{json .}}"];
+        args.extend_from_slice(&ids);
+        let out = self
+            .run_timeout(&args, BATCH_TIMEOUT)
+            .await?
+            .unwrap_or_default();
+        Ok(UsageReport::Sampled(parse_stats(&out)))
+    }
+}
+
+/// One line of `docker ps --format '{{json .}}'`.
+///
+/// Every field is optional and tolerantly typed because podman is a supported
+/// `CONTAINER_CLI` and does not agree with docker on all of them: `Names` is a
+/// string in docker and can be an array in podman, and `Labels` is a joined
+/// string in docker and an object in podman.
+#[derive(Deserialize)]
+struct PsRow {
+    #[serde(rename = "Names")]
+    names: Option<NameField>,
+    #[serde(rename = "State")]
+    state: Option<String>,
+    #[serde(rename = "Labels")]
+    labels: Option<LabelField>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum NameField {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl NameField {
+    fn first(&self) -> &str {
+        match self {
+            NameField::One(name) => name,
+            NameField::Many(names) => names.first().map(String::as_str).unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum LabelField {
+    /// docker: `a=1,b=2`. Ambiguous if a value contained a comma, which none
+    /// of CityHall's do (a numeric id, a docker tag, a hex fingerprint).
+    Joined(String),
+    Map(std::collections::HashMap<String, String>),
+}
+
+impl LabelField {
+    fn get(&self, key: &str) -> Option<&str> {
+        match self {
+            LabelField::Joined(joined) => joined
+                .split(',')
+                .filter_map(|pair| pair.split_once('='))
+                .find(|(k, _)| k.trim() == key)
+                .map(|(_, v)| v.trim()),
+            LabelField::Map(map) => map.get(key).map(String::as_str),
+        }
+    }
+}
+
+/// Runtime rows from `docker ps` output, skipping anything that is not an
+/// identifiable CityHall workspace. A line that does not parse is dropped
+/// rather than failing the batch: one odd container must not blank the whole
+/// dashboard.
+fn parse_ps(out: &str) -> Vec<WorkspaceRuntime> {
+    out.lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<PsRow>(line).ok())
+        .filter_map(|row| {
+            let user_id = row
+                .labels
+                .as_ref()
+                .and_then(|l| l.get(USER_ID_LABEL))
+                .and_then(|v| v.parse().ok())
+                // Pre-label containers, and any runtime whose ps output omits
+                // labels, still carry the id in their deterministic name.
+                .or_else(|| user_id_from_name(row.names.as_ref()?.first()))?;
+            Some(WorkspaceRuntime {
+                user_id,
+                running: row.state.as_deref() == Some("running"),
+                version: row
+                    .labels
+                    .as_ref()
+                    .and_then(|l| l.get(VERSION_LABEL))
+                    .map(str::to_string),
+            })
+        })
+        .collect()
+}
+
+/// The user id inside a workspace container name, inverting
+/// [`container_name`]. `None` for anything else on the host.
+fn user_id_from_name(name: &str) -> Option<i32> {
+    name.trim()
+        .trim_start_matches('/')
+        .strip_prefix("cityhall-workspace-u")?
+        .parse()
+        .ok()
+}
+
+/// One line of `docker stats --format '{{json .}}'`.
+#[derive(Deserialize)]
+struct StatsRow {
+    #[serde(rename = "Name")]
+    name: Option<NameField>,
+    #[serde(rename = "CPUPerc")]
+    cpu_perc: Option<String>,
+    #[serde(rename = "MemUsage")]
+    mem_usage: Option<String>,
+}
+
+/// Usage rows from `docker stats` output. A container that stopped between the
+/// listing and the sample, or whose figures do not parse, is skipped: its
+/// workspace shows a status with no usage, which beats reporting zeros or
+/// discarding everyone else's numbers.
+fn parse_stats(out: &str) -> Vec<WorkspaceUsage> {
+    out.lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<StatsRow>(line).ok())
+        .filter_map(|row| {
+            let user_id = user_id_from_name(row.name.as_ref()?.first())?;
+            let (memory_bytes, memory_limit_bytes) = parse_mem_usage(row.mem_usage.as_deref()?)?;
+            Some(WorkspaceUsage {
+                user_id,
+                cpu_percent: parse_cpu_percent(row.cpu_perc.as_deref()?)?,
+                memory_bytes,
+                memory_limit_bytes,
+            })
+        })
+        .collect()
+}
+
+/// `"0.05%"`, and podman's `"0.05 %"`.
+fn parse_cpu_percent(raw: &str) -> Option<f32> {
+    raw.trim().trim_end_matches('%').trim().parse().ok()
+}
+
+/// `"1.5MiB / 7.6GiB"` into `(used, Some(limit))`. An unlimited container can
+/// report a dash for the limit, which becomes `None` rather than zero.
+fn parse_mem_usage(raw: &str) -> Option<(u64, Option<u64>)> {
+    let (used, limit) = match raw.split_once('/') {
+        Some((used, limit)) => (used, Some(limit)),
+        None => (raw, None),
+    };
+    Some((parse_size(used)?, limit.and_then(parse_size)))
+}
+
+/// A container-runtime size: `"1.5MiB"` (IEC, docker) or `"1.5MB"` (SI,
+/// podman), and plain `"512B"` / `"512"`. The `i` decides the base, so the two
+/// are not silently conflated.
+fn parse_size(raw: &str) -> Option<u64> {
+    let raw = raw.trim();
+    let digits = raw
+        .trim_end_matches(|c: char| c.is_ascii_alphabetic())
+        .trim();
+    let unit = raw[digits.len()..].trim().to_ascii_lowercase();
+    let value: f64 = digits.parse().ok()?;
+    let base: f64 = if unit.contains('i') { 1024.0 } else { 1000.0 };
+    let exponent = match unit.trim_end_matches('b').trim_end_matches('i') {
+        "" => 0,
+        "k" => 1,
+        "m" => 2,
+        "g" => 3,
+        "t" => 4,
+        "p" => 5,
+        _ => return None,
+    };
+    let scaled = value * base.powi(exponent);
+    (scaled.is_finite() && scaled >= 0.0).then_some(scaled as u64)
 }
 
 struct ContainerState {
@@ -1047,6 +1289,159 @@ mod tests {
 
         let wrong_network = container_state("v1.0.0", Some("net-a"), None);
         assert!(needs_recreate(&wrong_network, &spec, Some("net-b")));
+    }
+
+    #[test]
+    fn ps_output_becomes_fleet_runtime_rows() {
+        // Real docker shapes: Labels joined, Names a string, State a word.
+        let out = concat!(
+            r#"{"ID":"a1","Names":"cityhall-workspace-u1","State":"running","Labels":"cityhall.managed=true,cityhall.user_id=1,cityhall.workspace.version=v1.2.3"}"#,
+            "\n",
+            r#"{"ID":"b2","Names":"cityhall-workspace-u2","State":"exited","Labels":"cityhall.managed=true,cityhall.user_id=2,cityhall.workspace.version=v1.0.0"}"#,
+            "\n"
+        );
+        let rows = parse_ps(out);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0],
+            WorkspaceRuntime {
+                user_id: 1,
+                running: true,
+                version: Some("v1.2.3".to_string()),
+            }
+        );
+        // Anything that is not literally "running" is not running: created,
+        // paused, and restarting must not read as live.
+        assert!(!rows[1].running);
+        assert_eq!(rows[1].user_id, 2);
+    }
+
+    /// podman is a supported `CONTAINER_CLI` and disagrees with docker on both
+    /// of these field shapes.
+    #[test]
+    fn ps_output_tolerates_podman_field_shapes() {
+        let out = concat!(
+            r#"{"Names":["cityhall-workspace-u7"],"State":"running","Labels":{"cityhall.managed":"true","cityhall.user_id":"7","cityhall.workspace.version":"v2.0.0"}}"#,
+            "\n"
+        );
+        let rows = parse_ps(out);
+        assert_eq!(
+            rows,
+            vec![WorkspaceRuntime {
+                user_id: 7,
+                running: true,
+                version: Some("v2.0.0".to_string()),
+            }]
+        );
+    }
+
+    /// The label is the identity contract, but a container created before it
+    /// existed still carries the id in its deterministic name.
+    #[test]
+    fn ps_falls_back_to_the_container_name_without_a_user_label() {
+        let out = r#"{"Names":"cityhall-workspace-u42","State":"running","Labels":"cityhall.managed=true"}"#;
+        let rows = parse_ps(out);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].user_id, 42);
+        assert_eq!(rows[0].version, None);
+    }
+
+    /// One unreadable line must not blank the fleet: the dashboard would go
+    /// from "one odd container" to "no workspaces exist".
+    #[test]
+    fn ps_skips_junk_and_foreign_containers_without_failing() {
+        let out = concat!(
+            "not json at all\n",
+            r#"{"Names":"some-other-app","State":"running","Labels":"role=web"}"#,
+            "\n",
+            "\n",
+            r#"{"Names":"cityhall-workspace-u5","State":"running","Labels":"cityhall.user_id=5"}"#,
+            "\n"
+        );
+        let rows = parse_ps(out);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].user_id, 5);
+        assert!(parse_ps("").is_empty());
+    }
+
+    #[test]
+    fn workspace_names_round_trip_to_user_ids() {
+        assert_eq!(user_id_from_name(&container_name(42)), Some(42));
+        // podman prefixes a slash on some outputs.
+        assert_eq!(user_id_from_name("/cityhall-workspace-u42"), Some(42));
+        assert_eq!(user_id_from_name("cityhall-workspace-u42-data"), None);
+        assert_eq!(user_id_from_name("postgres"), None);
+        assert_eq!(user_id_from_name(""), None);
+    }
+
+    #[test]
+    fn stats_output_becomes_usage_rows() {
+        let out = concat!(
+            r#"{"Name":"cityhall-workspace-u1","CPUPerc":"12.34%","MemUsage":"1.5MiB / 7.6GiB"}"#,
+            "\n",
+            r#"{"Name":"cityhall-workspace-u2","CPUPerc":"0.00%","MemUsage":"512B / 1KiB"}"#,
+            "\n"
+        );
+        let rows = parse_stats(out);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].user_id, 1);
+        assert!((rows[0].cpu_percent - 12.34).abs() < 0.001);
+        assert_eq!(rows[0].memory_bytes, 1_572_864);
+        assert_eq!(rows[0].memory_limit_bytes, Some(8_160_437_862));
+        assert_eq!(rows[1].memory_bytes, 512);
+        assert_eq!(rows[1].memory_limit_bytes, Some(1024));
+    }
+
+    /// A container can stop between the listing and the sample, and podman
+    /// spaces its percentage differently. Neither may cost the other rows.
+    #[test]
+    fn stats_skips_unusable_rows_and_accepts_podman_spacing() {
+        let out = concat!(
+            r#"{"Name":"cityhall-workspace-u1","CPUPerc":"--","MemUsage":"-- / --"}"#,
+            "\n",
+            r#"{"Name":"unrelated","CPUPerc":"5.00%","MemUsage":"1MiB / 2MiB"}"#,
+            "\n",
+            r#"{"Name":"cityhall-workspace-u3","CPUPerc":"7.50 %","MemUsage":"10.5 MB / 1 GB"}"#,
+            "\n"
+        );
+        let rows = parse_stats(out);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].user_id, 3);
+        assert!((rows[0].cpu_percent - 7.5).abs() < 0.001);
+        // SI units from podman, not silently read as IEC.
+        assert_eq!(rows[0].memory_bytes, 10_500_000);
+        assert_eq!(rows[0].memory_limit_bytes, Some(1_000_000_000));
+    }
+
+    /// A multi-core container legitimately exceeds 100%: clamping it here
+    /// would hide the most interesting case on the page.
+    #[test]
+    fn cpu_percent_above_one_core_is_preserved() {
+        assert_eq!(parse_cpu_percent("250.00%"), Some(250.0));
+        assert_eq!(parse_cpu_percent("0.00%"), Some(0.0));
+        assert_eq!(parse_cpu_percent("--"), None);
+        assert_eq!(parse_cpu_percent(""), None);
+    }
+
+    #[test]
+    fn sizes_distinguish_iec_from_si() {
+        assert_eq!(parse_size("1KiB"), Some(1024));
+        assert_eq!(parse_size("1kB"), Some(1000));
+        assert_eq!(parse_size("1GiB"), Some(1_073_741_824));
+        assert_eq!(parse_size("1GB"), Some(1_000_000_000));
+        assert_eq!(parse_size("512B"), Some(512));
+        assert_eq!(parse_size("512"), Some(512));
+        assert_eq!(parse_size("0B"), Some(0));
+        assert_eq!(parse_size("--"), None);
+        assert_eq!(parse_size("1ZiB"), None);
+        assert_eq!(parse_size(""), None);
+    }
+
+    #[test]
+    fn a_missing_memory_limit_is_absent_not_zero() {
+        assert_eq!(parse_mem_usage("1MiB"), Some((1_048_576, None)));
+        assert_eq!(parse_mem_usage("1MiB / --"), Some((1_048_576, None)));
+        assert_eq!(parse_mem_usage("-- / 1MiB"), None);
     }
 
     #[test]

--- a/api/src/orchestrator/mod.rs
+++ b/api/src/orchestrator/mod.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use serde::Serialize;
 
 /// Everything a backend needs to materialize a user's workspace.
 #[derive(Clone, Debug)]
@@ -182,6 +183,42 @@ pub struct BundleAccess {
     pub token: String,
 }
 
+/// Runtime state of every managed workspace, from one backend round-trip.
+///
+/// Deliberately carries no address. Resolving one costs an extra call per
+/// container (`docker port`) and only the proxy ever dials a workspace; every
+/// status *display* throws the address away.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceRuntime {
+    pub user_id: i32,
+    pub running: bool,
+    /// The version the runtime object was created with, when the backend
+    /// records one.
+    pub version: Option<String>,
+}
+
+/// Instantaneous resource usage of one workspace.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct WorkspaceUsage {
+    pub user_id: i32,
+    /// Share of one CPU, so a container using two cores flat reports 200.
+    pub cpu_percent: f32,
+    pub memory_bytes: u64,
+    pub memory_limit_bytes: Option<u64>,
+}
+
+/// Whether a backend can report per-workspace usage at all.
+///
+/// A named enum rather than `Option<Vec<_>>`: "this backend has no metrics
+/// source" and "nothing is running right now" are different things to render,
+/// and `Some(vec![])` versus `None` reads as a mistake at the call site.
+/// Transient collection failures are neither, and stay an `Err`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum UsageReport {
+    Unsupported,
+    Sampled(Vec<WorkspaceUsage>),
+}
+
 /// Runtime state of a workspace as reported by the backend.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WorkspaceStatus {
@@ -238,6 +275,23 @@ pub trait Orchestrator: Send + Sync {
 
     /// Current runtime state.
     async fn status(&self, user_id: i32) -> Result<WorkspaceStatus, OrchestratorError>;
+
+    /// Runtime state of every managed workspace in ONE round-trip, for callers
+    /// that would otherwise call [`Orchestrator::status`] once per user.
+    ///
+    /// `None` means this backend has no batch path, and the caller should fall
+    /// back to that per-user loop. An optional capability rather than a
+    /// required method so a backend gains it when someone can actually test
+    /// the batch command against a live runtime, instead of shipping an
+    /// unverified translation of it.
+    async fn statuses(&self) -> Result<Option<Vec<WorkspaceRuntime>>, OrchestratorError> {
+        Ok(None)
+    }
+
+    /// Per-workspace CPU and memory, when the backend has a metrics source.
+    async fn usage(&self) -> Result<UsageReport, OrchestratorError> {
+        Ok(UsageReport::Unsupported)
+    }
 }
 
 /// The backend selected by `WORKSPACE_BACKEND` (default `docker`), plus the

--- a/api/src/rbac.rs
+++ b/api/src/rbac.rs
@@ -32,6 +32,12 @@ pub const CATALOG: &[(&str, &str)] = &[
         "workspaces.impersonate",
         "Open other users' workspaces (audited)",
     ),
+    // Spelled out because granting it exposes operational metrics, not just
+    // another page: a role editor should be able to see that from the label.
+    (
+        "dashboard.read",
+        "View fleet status, workspace resource usage, and CityHall system metrics",
+    ),
 ];
 
 /// Built-in roles seeded on startup: (name, description, permission keys).

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -44,6 +44,10 @@ pub fn api_router(state: AppState) -> Router {
             get(users::get).patch(users::update).delete(users::delete),
         )
         .route("/dashboard", get(dashboard::overview))
+        .route(
+            "/me/dashboard-layout",
+            get(dashboard::get_layout).put(dashboard::put_layout),
+        )
         .route("/roles", get(roles::list).post(roles::create))
         .route("/roles/{id}", patch(roles::update).delete(roles::delete))
         .route("/permissions", get(roles::permissions))

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -10,7 +10,8 @@ use tower_http::trace::TraceLayer;
 
 use crate::error::AppError;
 use crate::handlers::{
-    agent_credentials, auth, oidc, roles, settings, signup, users, workspace_config, workspaces,
+    agent_credentials, auth, dashboard, oidc, roles, settings, signup, users, workspace_config,
+    workspaces,
 };
 use crate::proxy;
 use crate::state::AppState;
@@ -42,6 +43,7 @@ pub fn api_router(state: AppState) -> Router {
             "/users/{id}",
             get(users::get).patch(users::update).delete(users::delete),
         )
+        .route("/dashboard", get(dashboard::overview))
         .route("/roles", get(roles::list).post(roles::create))
         .route("/roles/{id}", patch(roles::update).delete(roles::delete))
         .route("/permissions", get(roles::permissions))
@@ -145,6 +147,7 @@ pub fn build_state(db: DatabaseConnection) -> Result<AppState, Box<dyn std::erro
         endpoints: Arc::default(),
         provisioning,
         versions: Arc::default(),
+        metrics: Arc::default(),
         proxy_client,
     })
 }
@@ -153,6 +156,7 @@ pub async fn serve(db: DatabaseConnection) -> Result<(), Box<dyn std::error::Err
     let state = build_state(db)?;
     crate::workspaces::seed_default_version(&state.db).await?;
     tokio::spawn(crate::workspaces::idle_sweeper(state.clone()));
+    tokio::spawn(crate::metrics::sampler(state.clone()));
 
     let addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -21,6 +21,9 @@ pub struct AppState {
     pub provisioning: Arc<ProvisioningRegistry>,
     /// Cached aoe release discovery feeding the version dropdowns.
     pub versions: Arc<crate::workspaces::VersionCache>,
+    /// Last fleet and system sample, published by the background sampler. The
+    /// dashboard reads it instead of shelling out per request.
+    pub metrics: Arc<crate::metrics::Metrics>,
     /// Client for proxied HTTP requests to workspaces (no redirects, HTTP/1.1
     /// so WebSocket upgrades tunnel through).
     pub proxy_client: reqwest::Client,

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,8 +25,8 @@ Every user has a role, and a role holds a set of permission keys (the wildcard
 `*` grants all). Endpoints require a specific permission; a caller lacking it
 gets `403 Forbidden` with `{"error":"insufficient permissions"}`. The current
 keys are `users.read`, `users.write`, `roles.read`, `roles.write`,
-`settings.read`, `settings.write`, `workspaces.use`, `workspaces.read`, and
-`workspaces.write`. `GET /api/auth/me` returns the caller's effective
+`settings.read`, `settings.write`, `workspaces.use`, `workspaces.read`,
+`workspaces.write`, and `dashboard.read`. `GET /api/auth/me` returns the caller's effective
 permission list so a client can gate its UI. Built-in roles are `admin` (all
 permissions) and `member` (`users.read`, `workspaces.use`).
 
@@ -415,6 +415,94 @@ Requires `settings.write`. Updates the self-signup configuration (same shape as
 unknown `signup_default_role_id` returns `400`. Enabling signup while SMTP is
 unconfigured returns `400` (verification email cannot be sent). Returns the
 updated settings.
+
+### `GET /api/dashboard`
+
+Requires `dashboard.read`, which also exposes CityHall's own system metrics and
+not only workspace state. Unrelated to the aoe telemetry policy in
+[Workspaces](workspaces.md#telemetry), which governs what workspaces report
+upstream.
+
+Served from a snapshot a background task refreshes every 10 seconds, so the
+figures are near-real-time rather than instantaneous and the endpoint costs the
+same however many workspaces exist. `sampled_at` is `null` until the first
+sample completes; `stale` means the sampler looks stuck rather than merely
+between ticks. `errors` lists sources that failed on the last attempt, and the
+values beside them are the last ones collected successfully.
+
+`usage` is per-workspace CPU and memory, keyed by `user_id`, and is only
+populated on the docker backend; `usage_supported` is `false` where the backend
+has no metrics source, which is different from nothing running. `cpu_percent` is
+a share of one CPU, so a workspace using two cores reports `200`.
+
+`system` describes the machine as CityHall sees it, which is not necessarily the
+machine running the workspaces: `scope` is `host` or `cityhall_container`.
+`cgroup_memory` is CityHall's own limit when it is narrower than the system's,
+and never replaces the totals. `disk` is `null` unless
+`SYSTEM_METRICS_DISK_PATH` is configured (see
+[Configuration](configuration.md)).
+
+```json
+{
+  "sampled_at": "2026-08-04T18:44:11Z",
+  "stale": false,
+  "errors": [],
+  "system": {
+    "scope": "host",
+    "cpu_percent": 40.2,
+    "cpu_count": 12,
+    "memory_used_bytes": 25886179328,
+    "memory_total_bytes": 34359738368,
+    "cgroup_memory": null,
+    "disk": { "path": "/", "mount_point": "/", "used_bytes": 973773684736, "total_bytes": 994662584320 }
+  },
+  "usage_supported": true,
+  "usage": [{ "user_id": 2, "cpu_percent": 12.3, "memory_bytes": 1572864, "memory_limit_bytes": 8160437862 }],
+  "workspaces": [
+    {
+      "user_id": 2,
+      "username": "bob",
+      "status": "running",
+      "effective_version": "v0.5.0",
+      "running_version": "v0.5.0",
+      "last_active_at": "2026-07-15T09:20:50Z",
+      "provisioning": null
+    }
+  ],
+  "summary": {
+    "total_users": 1,
+    "running": 1,
+    "stopped": 0,
+    "not_created": 0,
+    "unknown": 0,
+    "provisioning": 0,
+    "usage_available": 1
+  },
+  "versions": [{ "version": "v0.5.0", "count": 1 }]
+}
+```
+
+### `GET /api/me/dashboard-layout`
+
+Requires `dashboard.read`. The caller's saved dashboard widget arrangement, or
+`{"layout": null}` when they have never customized it. A stored layout from an
+incompatible schema version reads as `null` rather than failing.
+
+### `PUT /api/me/dashboard-layout`
+
+Requires `dashboard.read`. Saves the caller's own arrangement and returns `204`.
+
+```json
+{
+  "schema_version": 1,
+  "items": [{ "id": "system-usage", "x": 0, "y": 0, "w": 6, "h": 7 }],
+  "hidden": ["versions"]
+}
+```
+
+At most 32 items and 32 hidden ids, widget ids matching
+`[a-z][a-z0-9-]{0,63}`, no duplicates, and `x + w` within the 12-column grid;
+anything else returns `400`. Concurrent saves are last-write-wins.
 
 ### `GET /api/workspaces`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,25 @@ connections from outside the container. `STATIC_DIR` is where the server looks
 for the built frontend (`index.html` plus assets); requests that do not match
 `/api/*` fall back to `index.html` so client-side routes resolve on refresh.
 
+## Dashboard system metrics
+
+The Dashboard's system card reports the machine as the CityHall process sees it.
+When CityHall runs in a container that is usually the host's CPU and memory
+rather than its own, so the card is labelled with what it is showing.
+
+`SYSTEM_METRICS_SCOPE` overrides that label with `host` or `container`.
+CityHall detects it from `/.dockerenv` and PID 1's cgroup, which covers docker,
+compose, podman, containerd, and kubernetes; set it when the guess is wrong.
+
+`SYSTEM_METRICS_DISK_PATH` names a filesystem to report, for example
+`/var/lib/docker`. There is deliberately no default and the disk figure is
+omitted when it is unset: under an overlay filesystem the obvious choice, `/`,
+measures CityHall's own image layers rather than the storage workspaces use, so
+a default would put a confidently wrong number on the page. The mount point
+actually holding the path is shown beside it. Measuring a docker volume's
+backing storage from inside a container requires mounting that host path into
+CityHall.
+
 ## Logging
 
 CityHall logs with [`tracing`](https://docs.rs/tracing). There are two ways to

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -117,7 +117,16 @@ Notes on that build, all learned the hard way:
 
 Members hold the `workspaces.use` permission by default and can open their own
 workspace. `workspaces.read` / `workspaces.write` gate the admin Workspaces
-page and its actions.
+page and its actions. `dashboard.read` gates the Dashboard page, and grants
+more than workspace state: it also exposes CityHall's own CPU, memory, and
+disk figures.
+
+Two things about the Dashboard are not visible from the page itself. Its
+numbers come from a snapshot refreshed every 10 seconds, not from a live read,
+so they lag actions by up to that long; the page shows how old the sample is.
+And per-workspace CPU and memory come from `docker stats`, so they are only
+available on the docker backend. The kubernetes and process backends report
+status without usage rather than reporting zeros.
 
 `workspaces.impersonate` (never implied by `workspaces.read`) lets an admin
 open another user's workspace for support: the Open action mints a short-lived

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "lucide-react": "^1.23.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "react-grid-layout": "^2.2.4",
         "react-router-dom": "^7.18.1",
         "smol-toml": "^1.7.1",
         "tailwindcss": "^4.3.2"
@@ -1983,6 +1984,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2156,6 +2163,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -2467,6 +2480,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.23.0.tgz",
@@ -2532,6 +2557,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.3",
@@ -2732,6 +2766,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2761,6 +2806,58 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.7.1.tgz",
+      "integrity": "sha512-wa3tzfFnYt3yaZLuyU58fl1TNunfWfBekDgWhZA1+gb2jnp42wZ0ymuopR6M5kqDYmm4hKmzGlcKWjZf3Zb6RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.4.tgz",
+      "integrity": "sha512-Eb57FsgOMYOfsUGrMI1ku/FFR+dPNPrE8qo+3hwZubpqVSy4GO9v52DeX50Tl3JDYAlCypP4rmw7Vrqk/zOIvA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.1.3",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-resizable": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.2.0.tgz",
+      "integrity": "sha512-3NKQ0SLZV7rs3LQHeXlOzDSRQfFrkX6TVet77/Qk03zqiZyee37b7N8/gwDJAA8UUjRz7PdWCCy49hcso45SMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3",
+        "react-dom": ">= 16.3"
       }
     },
     "node_modules/react-router": {
@@ -2800,6 +2897,12 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.1.4",

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^1.23.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "react-grid-layout": "^2.2.4",
     "react-router-dom": "^7.18.1",
     "smol-toml": "^1.7.1",
     "tailwindcss": "^4.3.2"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
-import { api, ApiError, type Me } from "./lib/api";
+import { api, ApiError, can, type Me } from "./lib/api";
+import { DashboardPage } from "./components/DashboardPage";
 import { LoginPage } from "./components/LoginPage";
 import { ChangePasswordPage } from "./components/ChangePasswordPage";
 import { UsersPage } from "./components/UsersPage";
@@ -59,8 +60,36 @@ export function App() {
           )
         }
       />
+      {/* `/` redirects rather than rendering a different component per role, so
+          every page keeps one stable URL that bookmarks and history can hold. */}
       <Route
         path="/"
+        element={
+          !me ? (
+            <Navigate to="/login" replace />
+          ) : me.must_change_password ? (
+            <Navigate to="/change-password" replace />
+          ) : (
+            <Navigate to={can(me, "dashboard.read") ? "/dashboard" : "/users"} replace />
+          )
+        }
+      />
+      <Route
+        path="/dashboard"
+        element={
+          !me ? (
+            <Navigate to="/login" replace />
+          ) : me.must_change_password ? (
+            <Navigate to="/change-password" replace />
+          ) : !can(me, "dashboard.read") ? (
+            <Navigate to="/users" replace />
+          ) : (
+            <DashboardPage me={me} onLogout={refresh} />
+          )
+        }
+      />
+      <Route
+        path="/users"
         element={
           !me ? (
             <Navigate to="/login" replace />

--- a/web/src/components/DashboardPage.tsx
+++ b/web/src/components/DashboardPage.tsx
@@ -1,0 +1,220 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import GridLayout, { useContainerWidth, type Layout } from "react-grid-layout";
+import { Check, Pencil, RotateCcw } from "lucide-react";
+import { api, ApiError, type Dashboard, type DashboardLayout, type DashboardLayoutItem, type Me } from "../lib/api";
+import {
+  applyPositions,
+  defaultLayout,
+  EDIT_MIN_WIDTH,
+  formatAge,
+  GRID_COLUMNS,
+  mergeLayout,
+  toggleWidget,
+  visibleWidgets,
+  WIDGETS,
+} from "../lib/dashboardLayout";
+import { TopBar } from "./TopBar";
+import { Button } from "./ui";
+import { WIDGET_BODIES } from "./dashboard/widgets";
+
+/// Matched to the sampler's own interval: polling faster only re-reads the same
+/// snapshot, since the request path does no collection of its own.
+const POLL_MS = 10_000;
+const ROW_HEIGHT = 40;
+
+export function DashboardPage({ me, onLogout }: { me: Me; onLogout: () => Promise<void> }) {
+  const [data, setData] = useState<Dashboard | null>(null);
+  const [layout, setLayout] = useState<DashboardLayout>(() => defaultLayout());
+  const [editing, setEditing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Re-rendered on a timer so the freshness line counts up between polls
+  // rather than sitting on a stale "10s ago".
+  const [, setTick] = useState(0);
+  const { width, containerRef, mounted } = useContainerWidth();
+  // Positions from the current drag session, kept out of state so a poll
+  // cannot re-render mid-drag and fight the pointer. Only the positions live
+  // here; visibility stays in `layout`, so a session that just toggles a
+  // widget still saves.
+  const dragged = useRef<DashboardLayoutItem[] | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setData(await api.dashboard());
+      setError(null);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "could not load the dashboard");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    api
+      .getDashboardLayout()
+      .then(({ layout: stored }) => setLayout(mergeLayout(stored)))
+      // A layout that will not load is not worth blocking the dashboard for;
+      // the defaults are a working fallback.
+      .catch(() => setLayout(defaultLayout()));
+  }, [load]);
+
+  // Paused while editing: a re-render mid-drag fights the pointer.
+  useEffect(() => {
+    if (editing) return;
+    const refresh = () => {
+      if (!document.hidden) void load();
+    };
+    const poll = setInterval(refresh, POLL_MS);
+    const age = setInterval(() => setTick((t) => t + 1), 1_000);
+    document.addEventListener("visibilitychange", refresh);
+    window.addEventListener("focus", refresh);
+    return () => {
+      clearInterval(poll);
+      clearInterval(age);
+      document.removeEventListener("visibilitychange", refresh);
+      window.removeEventListener("focus", refresh);
+    };
+  }, [editing, load]);
+
+  const canEdit = width >= EDIT_MIN_WIDTH;
+  // Leaving a narrow viewport mid-edit would otherwise strand the Done button.
+  useEffect(() => {
+    if (!canEdit) setEditing(false);
+  }, [canEdit]);
+
+  async function save(next: DashboardLayout) {
+    setLayout(next);
+    try {
+      await api.saveDashboardLayout(next);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : "could not save the layout");
+    }
+  }
+
+  function onLayoutChange(next: Layout) {
+    if (!editing) return;
+    dragged.current = next.map((item) => ({ id: item.i, x: item.x, y: item.y, w: item.w, h: item.h }));
+  }
+
+  async function done() {
+    setEditing(false);
+    const positions = dragged.current;
+    dragged.current = null;
+    // Saved from live state either way: an edit session that only toggled a
+    // widget off never produces a drag, and would otherwise save nothing.
+    await save(positions ? applyPositions(layout, positions) : layout);
+  }
+
+  async function reset() {
+    // Drop any positions from this session, or Done would fold them back in
+    // on top of the defaults just restored.
+    dragged.current = null;
+    await save(defaultLayout());
+  }
+
+  const visible = visibleWidgets(layout);
+  const gridLayout: Layout = visible.map((widget) => {
+    const item = layout.items.find((i) => i.id === widget.id) ?? { ...widget.default, id: widget.id };
+    return { i: widget.id, x: item.x, y: item.y, w: item.w, h: item.h, minW: widget.minW, minH: widget.minH };
+  });
+
+  return (
+    <div className="flex h-full flex-col">
+      <TopBar me={me} onLogout={onLogout} />
+      <main className="flex-1 overflow-auto p-6">
+        <div className="mx-auto w-full max-w-7xl space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-baseline gap-3">
+              <h2 className="font-mono text-xs uppercase tracking-wider text-text-muted">Dashboard</h2>
+              {data && (
+                <span className={data.stale ? "text-xs text-status-error" : "text-xs text-text-muted"}>
+                  {data.sampled_at ? `updated ${formatAge(data.sampled_at)}` : "collecting the first sample"}
+                </span>
+              )}
+            </div>
+            {canEdit && (
+              <div className="flex items-center gap-2">
+                {editing && (
+                  <Button variant="ghost" onClick={() => void reset()} className="flex items-center gap-1.5">
+                    <RotateCcw size={14} />
+                    Reset layout
+                  </Button>
+                )}
+                <Button
+                  variant={editing ? "primary" : "ghost"}
+                  onClick={() => (editing ? void done() : setEditing(true))}
+                  className="flex items-center gap-1.5"
+                >
+                  {editing ? <Check size={14} /> : <Pencil size={14} />}
+                  {editing ? "Done" : "Edit layout"}
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {error && <p className="text-sm text-status-error">{error}</p>}
+
+          {data && data.errors.length > 0 && (
+            <div className="space-y-1 rounded-md border border-surface-700 bg-surface-850 px-4 py-3 text-sm">
+              {data.errors.map((message) => (
+                <p key={message} className="text-status-waiting">
+                  {message}
+                </p>
+              ))}
+              <p className="text-xs text-text-muted">The figures below are the last ones collected successfully.</p>
+            </div>
+          )}
+
+          {editing && (
+            <div className="flex flex-wrap items-center gap-3 rounded-md border border-surface-700 bg-surface-850 px-4 py-3">
+              <span className="text-sm text-text-secondary">Drag a card by its title; resize from its corner.</span>
+              {WIDGETS.map((widget) => (
+                <label key={widget.id} className="flex items-center gap-1.5 text-xs text-text-secondary">
+                  <input
+                    type="checkbox"
+                    checked={!layout.hidden.includes(widget.id)}
+                    onChange={() => setLayout((current) => toggleWidget(current, widget.id))}
+                    className="h-4 w-4 accent-brand-500"
+                  />
+                  {widget.title}
+                </label>
+              ))}
+            </div>
+          )}
+
+          <div ref={containerRef}>
+            {mounted && data && (
+              <GridLayout
+                width={width}
+                layout={gridLayout}
+                onLayoutChange={onLayoutChange}
+                gridConfig={{ cols: GRID_COLUMNS, rowHeight: ROW_HEIGHT, margin: [16, 16], containerPadding: [0, 0] }}
+                // Off until Edit, and handled by the title bar only, so a click
+                // on a table row or a button never starts a drag.
+                dragConfig={{ enabled: editing, handle: ".dashboard-drag-handle" }}
+                resizeConfig={{ enabled: editing }}
+              >
+                {visible.map((widget) => {
+                  const Body = WIDGET_BODIES[widget.id];
+                  return (
+                    <div
+                      key={widget.id}
+                      className="flex flex-col overflow-hidden rounded-lg border border-surface-700 bg-surface-900"
+                    >
+                      <div
+                        className={`dashboard-drag-handle border-b border-surface-700 px-4 py-2 ${editing ? "cursor-move" : ""}`}
+                      >
+                        <h3 className="font-mono text-xs uppercase tracking-wider text-text-muted">{widget.title}</h3>
+                      </div>
+                      <div className="flex-1 overflow-auto p-4">{Body && <Body data={data} />}</div>
+                    </div>
+                  );
+                })}
+              </GridLayout>
+            )}
+            {!data && !error && <p className="text-sm text-text-muted">Loading...</p>}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { Boxes, ExternalLink, LogOut, Settings, Shield, User, Users } from "lucide-react";
+import { Boxes, ExternalLink, LayoutDashboard, LogOut, Settings, Shield, User, Users } from "lucide-react";
 import { useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
 import { api, can, type Me } from "../lib/api";
@@ -33,7 +33,13 @@ export function TopBar({ me, onLogout }: { me: Me; onLogout: () => Promise<void>
       <div className="flex items-center gap-4">
         <span className="font-mono text-sm font-medium tracking-wider text-text-bright">CityHall</span>
         <nav className="flex items-center gap-1">
-          <NavLink to="/" end className={navLinkClass}>
+          {can(me, "dashboard.read") && (
+            <NavLink to="/dashboard" className={navLinkClass}>
+              <LayoutDashboard size={14} />
+              Dashboard
+            </NavLink>
+          )}
+          <NavLink to="/users" className={navLinkClass}>
             <Users size={14} />
             Users
           </NavLink>

--- a/web/src/components/dashboard/widgets.tsx
+++ b/web/src/components/dashboard/widgets.tsx
@@ -1,0 +1,213 @@
+import clsx from "clsx";
+import type { Dashboard, DashboardWorkspace, MetricScope, WorkspaceUsage } from "../../lib/api";
+import { formatBytes, formatPercent } from "../../lib/dashboardLayout";
+
+const STATUS_STYLES: Record<DashboardWorkspace["status"], string> = {
+  running: "text-status-running",
+  stopped: "text-status-waiting",
+  not_created: "text-text-muted",
+  unknown: "text-status-error",
+};
+
+const STATUS_LABELS: Record<DashboardWorkspace["status"], string> = {
+  running: "running",
+  stopped: "stopped",
+  not_created: "not created",
+  unknown: "unknown",
+};
+
+/// What the system figures actually measure. Shown next to them because
+/// CityHall usually runs in a container beside the workspaces it reports on,
+/// where these are not host figures and reading them as such is how an incident
+/// gets misdiagnosed.
+const SCOPE_LABELS: Record<MetricScope, string> = {
+  host: "CityHall host",
+  cityhall_container: "System visible to CityHall",
+};
+
+/// `danger` is opt-in because "nearly full" only means trouble for a capacity
+/// bar. A version holding the whole fleet is the normal end state of a rollout,
+/// and colouring that red reads as an alert about nothing.
+function Meter({ used, total, danger = false }: { used: number; total: number; danger?: boolean }) {
+  const percent = total > 0 ? Math.min(100, (used / total) * 100) : 0;
+  return (
+    <div className="h-1.5 overflow-hidden rounded-full bg-surface-800">
+      <div
+        className={clsx("h-full rounded-full", danger && percent > 90 ? "bg-status-error" : "bg-brand-500")}
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="font-mono text-xs uppercase tracking-wider text-text-muted">{label}</p>
+      <p className="text-lg text-text-primary">{value}</p>
+    </div>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm text-text-muted">{children}</p>;
+}
+
+export function SystemUsageWidget({ data }: { data: Dashboard }) {
+  if (!data.system) return <Empty>No system figures in the latest sample.</Empty>;
+  const { scope, cpu_percent, cpu_count, memory_used_bytes, memory_total_bytes, cgroup_memory, disk } = data.system;
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-text-muted">
+        {SCOPE_LABELS[scope]}
+        {scope === "cityhall_container" && " (not necessarily the workspace host)"}
+      </p>
+      <div className="grid grid-cols-2 gap-4">
+        <Stat label={`CPU (${cpu_count} cores)`} value={formatPercent(cpu_percent)} />
+        <Stat label="Memory" value={`${formatBytes(memory_used_bytes)} / ${formatBytes(memory_total_bytes)}`} />
+      </div>
+      <Meter used={memory_used_bytes} total={memory_total_bytes} danger />
+      {cgroup_memory && (
+        <div className="space-y-1.5">
+          <p className="font-mono text-xs uppercase tracking-wider text-text-muted">CityHall memory limit</p>
+          <p className="text-sm text-text-secondary">
+            {formatBytes(cgroup_memory.used_bytes)} / {formatBytes(cgroup_memory.limit_bytes)}
+          </p>
+          <Meter used={cgroup_memory.used_bytes} total={cgroup_memory.limit_bytes} danger />
+        </div>
+      )}
+      {disk ? (
+        <div className="space-y-1.5">
+          <p className="font-mono text-xs uppercase tracking-wider text-text-muted">Disk {disk.mount_point}</p>
+          <p className="text-sm text-text-secondary">
+            {formatBytes(disk.used_bytes)} / {formatBytes(disk.total_bytes)}
+          </p>
+          <Meter used={disk.used_bytes} total={disk.total_bytes} danger />
+        </div>
+      ) : (
+        <p className="text-xs text-text-muted">
+          Set <code className="text-text-secondary">SYSTEM_METRICS_DISK_PATH</code> to report a filesystem.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function FleetStatusWidget({ data }: { data: Dashboard }) {
+  const { summary } = data;
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <Stat label="Running" value={String(summary.running)} />
+      <Stat label="Stopped" value={String(summary.stopped)} />
+      <Stat label="Not created" value={String(summary.not_created)} />
+      <Stat label="Unknown" value={String(summary.unknown)} />
+      <Stat label="Users" value={String(summary.total_users)} />
+      <Stat label="Provisioning" value={String(summary.provisioning)} />
+    </div>
+  );
+}
+
+export function ContainersWidget({ data }: { data: Dashboard }) {
+  const usage = new Map<number, WorkspaceUsage>(data.usage.map((u) => [u.user_id, u]));
+  if (data.workspaces.length === 0) return <Empty>No users.</Empty>;
+  return (
+    <div className="space-y-2">
+      {!data.usage_supported && (
+        <p className="text-xs text-text-muted">Resource usage is not available on this workspace backend.</p>
+      )}
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-surface-700 text-left font-mono text-xs uppercase tracking-wider text-text-muted">
+            <th className="py-2 pr-4 font-medium">User</th>
+            <th className="py-2 pr-4 font-medium">Status</th>
+            <th className="py-2 pr-4 font-medium">Version</th>
+            {data.usage_supported && <th className="py-2 pr-4 text-right font-medium">CPU</th>}
+            {data.usage_supported && <th className="py-2 text-right font-medium">Memory</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {data.workspaces.map((w) => {
+            const u = usage.get(w.user_id);
+            return (
+              <tr key={w.user_id} className="border-b border-surface-800 last:border-0">
+                <td className="py-2 pr-4 text-text-primary">{w.username}</td>
+                <td className="py-2 pr-4">
+                  {w.provisioning ? (
+                    <span
+                      className={w.provisioning.failed ? "text-status-error" : "text-status-waiting"}
+                      title={w.provisioning.message}
+                    >
+                      {w.provisioning.failed ? "provisioning failed" : "provisioning"}
+                    </span>
+                  ) : (
+                    <span className={STATUS_STYLES[w.status]}>{STATUS_LABELS[w.status]}</span>
+                  )}
+                </td>
+                <td className="py-2 pr-4 text-text-secondary">
+                  {w.effective_version ?? "-"}
+                  {/* Only worth showing when they disagree, which means a version
+                      change is waiting for a restart. */}
+                  {w.running_version && w.running_version !== w.effective_version && (
+                    <span className="ml-1.5 text-xs text-status-waiting" title="running until the next restart">
+                      running {w.running_version}
+                    </span>
+                  )}
+                </td>
+                {data.usage_supported && (
+                  <td className="py-2 pr-4 text-right text-text-secondary">{u ? formatPercent(u.cpu_percent) : "-"}</td>
+                )}
+                {data.usage_supported && (
+                  <td className="py-2 text-right text-text-secondary">{u ? formatBytes(u.memory_bytes) : "-"}</td>
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function VersionsWidget({ data }: { data: Dashboard }) {
+  if (data.versions.length === 0) return <Empty>No workspace version configured.</Empty>;
+  const total = data.versions.reduce((sum, v) => sum + v.count, 0);
+  return (
+    <div className="space-y-2.5">
+      {data.versions.map((v) => (
+        <div key={v.version} className="space-y-1">
+          <div className="flex justify-between text-sm">
+            <span className="text-text-primary">{v.version}</span>
+            <span className="text-text-muted">{v.count}</span>
+          </div>
+          <Meter used={v.count} total={total} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ProvisioningWidget({ data }: { data: Dashboard }) {
+  const jobs = data.workspaces.flatMap((w) => (w.provisioning ? [{ w, info: w.provisioning }] : []));
+  if (jobs.length === 0) return <Empty>Nothing provisioning.</Empty>;
+  return (
+    <div className="space-y-1.5 text-sm">
+      {jobs.map(({ w, info }) => (
+        <p key={w.user_id} className={info.failed ? "text-status-error" : "text-status-waiting"}>
+          <span className="font-medium text-text-primary">{w.username}</span>: {info.message}
+        </p>
+      ))}
+      <p className="text-xs text-text-muted">
+        A first image pull or local build takes a few minutes and continues if this page is closed.
+      </p>
+    </div>
+  );
+}
+
+/// Maps a catalog widget id to what renders inside its card.
+export const WIDGET_BODIES: Record<string, (props: { data: Dashboard }) => React.ReactNode> = {
+  "system-usage": SystemUsageWidget,
+  "fleet-status": FleetStatusWidget,
+  containers: ContainersWidget,
+  versions: VersionsWidget,
+  provisioning: ProvisioningWidget,
+};

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -39,6 +39,11 @@
 
 @import "tailwindcss";
 
+/* Grid positioning and resize handles for the dashboard's widget layout.
+   Imported after Tailwind so its preflight reset cannot flatten the handles. */
+@import "react-grid-layout/css/styles.css";
+@import "react-resizable/css/styles.css";
+
 /* Zinc theme, mirrored from Agent of Empires' default web palette. */
 @theme {
   /* Brand -- amber/copper, used sparingly (focus rings, active accents) */

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -117,6 +117,86 @@ export interface WorkspaceItem {
   provisioning: { message: string; failed: boolean } | null;
 }
 
+/// What the system figures describe. CityHall often runs in a container beside
+/// the workspaces it reports on, so the scope is shown rather than assumed.
+export type MetricScope = "host" | "cityhall_container";
+
+export interface DiskUsage {
+  path: string;
+  mount_point: string;
+  used_bytes: number;
+  total_bytes: number;
+}
+
+export interface SystemUsage {
+  scope: MetricScope;
+  cpu_percent: number;
+  cpu_count: number;
+  memory_used_bytes: number;
+  memory_total_bytes: number;
+  /// CityHall's own cgroup limit when it is narrower than the system's. Never a
+  /// replacement for the totals above.
+  cgroup_memory: { used_bytes: number; limit_bytes: number } | null;
+  /// Only set when SYSTEM_METRICS_DISK_PATH is configured.
+  disk: DiskUsage | null;
+}
+
+export interface WorkspaceUsage {
+  user_id: number;
+  /// Share of one CPU, so a container on two cores reads 200. Not clamped.
+  cpu_percent: number;
+  memory_bytes: number;
+  memory_limit_bytes: number | null;
+}
+
+export interface DashboardWorkspace {
+  user_id: number;
+  username: string;
+  status: "not_created" | "stopped" | "running" | "unknown";
+  effective_version: string | null;
+  running_version: string | null;
+  last_active_at: string | null;
+  provisioning: { message: string; failed: boolean } | null;
+}
+
+export interface DashboardSummary {
+  total_users: number;
+  running: number;
+  stopped: number;
+  not_created: number;
+  unknown: number;
+  provisioning: number;
+  usage_available: number;
+}
+
+export interface Dashboard {
+  /// Null until the sampler's first tick, which reads as "collecting".
+  sampled_at: string | null;
+  stale: boolean;
+  errors: string[];
+  system: SystemUsage | null;
+  /// False when the backend has no metrics source at all.
+  usage_supported: boolean;
+  usage: WorkspaceUsage[];
+  workspaces: DashboardWorkspace[];
+  summary: DashboardSummary;
+  versions: { version: string; count: number }[];
+}
+
+export interface DashboardLayoutItem {
+  id: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface DashboardLayout {
+  schema_version: number;
+  items: DashboardLayoutItem[];
+  hidden: string[];
+}
+
 export interface MyWorkspace {
   status: "not_created" | "stopped" | "running" | "unknown";
   pinned_version: string | null;
@@ -335,6 +415,10 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(patch),
     }),
+  dashboard: () => request<Dashboard>("/dashboard"),
+  getDashboardLayout: () => request<{ layout: DashboardLayout | null }>("/me/dashboard-layout"),
+  saveDashboardLayout: (layout: DashboardLayout) =>
+    request<void>("/me/dashboard-layout", { method: "PUT", body: JSON.stringify(layout) }),
   listWorkspaces: () => request<WorkspaceItem[]>("/workspaces"),
   myWorkspace: () => request<MyWorkspace>("/workspaces/me"),
   startWorkspace: (userId: number) => request<{ status: string }>(`/workspaces/${userId}/start`, { method: "POST" }),

--- a/web/src/lib/dashboardLayout.test.ts
+++ b/web/src/lib/dashboardLayout.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import type { DashboardLayout } from "./api";
+import {
+  applyPositions,
+  defaultLayout,
+  formatAge,
+  formatBytes,
+  formatPercent,
+  GRID_COLUMNS,
+  LAYOUT_SCHEMA_VERSION,
+  mergeLayout,
+  toggleWidget,
+  visibleWidgets,
+  WIDGETS,
+} from "./dashboardLayout";
+
+// There is no @testing-library/react in this repo, so these cover the pure
+// layout reconciliation and formatting the dashboard is built on, which is
+// where the drift between a saved layout and the shipped widget catalog is
+// actually handled.
+
+describe("mergeLayout", () => {
+  it("falls back to defaults for anything unusable", () => {
+    expect(mergeLayout(null)).toEqual(defaultLayout());
+    // A layout written by a future build must not half-apply.
+    expect(mergeLayout({ schema_version: 99, items: [], hidden: [] })).toEqual(defaultLayout());
+    // Hand-edited junk that got past a stale validator.
+    expect(mergeLayout({ schema_version: 1, items: null, hidden: null } as unknown as DashboardLayout)).toEqual(
+      defaultLayout(),
+    );
+  });
+
+  it("keeps saved positions", () => {
+    const stored: DashboardLayout = {
+      schema_version: LAYOUT_SCHEMA_VERSION,
+      items: WIDGETS.map((w, i) => ({ id: w.id, x: 0, y: i * 4, w: 12, h: 4 })),
+      hidden: [],
+    };
+    const merged = mergeLayout(stored);
+    expect(merged.items).toHaveLength(WIDGETS.length);
+    expect(merged.items[0]).toEqual({ id: WIDGETS[0].id, x: 0, y: 0, w: 12, h: 4 });
+  });
+
+  it("appends a widget added after the layout was saved", () => {
+    // A layout from a release that only had the first widget.
+    const stored: DashboardLayout = {
+      schema_version: LAYOUT_SCHEMA_VERSION,
+      items: [{ id: WIDGETS[0].id, x: 0, y: 0, w: 6, h: 4 }],
+      hidden: [],
+    };
+    const merged = mergeLayout(stored);
+    expect(merged.items).toHaveLength(WIDGETS.length);
+    // Placed below what was already positioned rather than on top of it.
+    const appended = merged.items.filter((i) => i.id !== WIDGETS[0].id);
+    expect(appended.every((i) => i.y >= 4)).toBe(true);
+  });
+
+  it("drops ids for widgets that no longer exist", () => {
+    const stored: DashboardLayout = {
+      schema_version: LAYOUT_SCHEMA_VERSION,
+      items: [
+        { id: WIDGETS[0].id, x: 0, y: 0, w: 6, h: 4 },
+        { id: "widget-from-an-old-release", x: 6, y: 0, w: 6, h: 4 },
+      ],
+      hidden: ["also-gone"],
+    };
+    const merged = mergeLayout(stored);
+    expect(merged.items.map((i) => i.id).sort()).toEqual(WIDGETS.map((w) => w.id).sort());
+    expect(merged.hidden).toEqual([]);
+  });
+
+  it("honors hidden widgets that still exist", () => {
+    const stored: DashboardLayout = { ...defaultLayout(), hidden: [WIDGETS[1].id] };
+    const merged = mergeLayout(stored);
+    expect(merged.hidden).toEqual([WIDGETS[1].id]);
+    expect(visibleWidgets(merged).map((w) => w.id)).not.toContain(WIDGETS[1].id);
+    expect(visibleWidgets(merged)).toHaveLength(WIDGETS.length - 1);
+  });
+
+  it("clamps geometry into the grid", () => {
+    const stored: DashboardLayout = {
+      schema_version: LAYOUT_SCHEMA_VERSION,
+      items: [
+        // Wider than the grid, off the right edge, and negative.
+        { id: WIDGETS[0].id, x: 99, y: -5, w: 99, h: 0 },
+        { id: WIDGETS[1].id, x: -1, y: 0, w: 1, h: 1 },
+      ],
+      hidden: [],
+    };
+    const merged = mergeLayout(stored);
+    for (const item of merged.items) {
+      expect(item.x).toBeGreaterThanOrEqual(0);
+      expect(item.y).toBeGreaterThanOrEqual(0);
+      expect(item.w).toBeGreaterThan(0);
+      expect(item.h).toBeGreaterThan(0);
+      expect(item.x + item.w).toBeLessThanOrEqual(GRID_COLUMNS);
+    }
+    // A widget narrower than its minimum is widened, not left unusable.
+    const second = merged.items.find((i) => i.id === WIDGETS[1].id)!;
+    expect(second.w).toBeGreaterThanOrEqual(WIDGETS[1].minW);
+    expect(second.h).toBeGreaterThanOrEqual(WIDGETS[1].minH);
+  });
+
+  it("produces a layout the backend will accept", () => {
+    const merged = mergeLayout(null);
+    expect(merged.schema_version).toBe(LAYOUT_SCHEMA_VERSION);
+    expect(merged.items.length).toBeLessThanOrEqual(32);
+    const ids = merged.items.map((i) => i.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^[a-z][a-z0-9-]{0,63}$/);
+  });
+});
+
+describe("applyPositions", () => {
+  it("keeps the stored position of a widget the grid did not render", () => {
+    // The grid only reports what it drew, so a hidden widget is absent from
+    // the callback. Overwriting items wholesale would lose where it sat, which
+    // is the position it needs when it is shown again.
+    const start = { ...defaultLayout(), hidden: [WIDGETS[1].id] };
+    const fromGrid = [{ id: WIDGETS[0].id, x: 6, y: 2, w: 6, h: 5 }];
+
+    const applied = applyPositions(start, fromGrid);
+    expect(applied.items.find((i) => i.id === WIDGETS[0].id)).toEqual(fromGrid[0]);
+    expect(applied.items.find((i) => i.id === WIDGETS[1].id)).toEqual(start.items.find((i) => i.id === WIDGETS[1].id));
+    // Every widget survives, and visibility is untouched.
+    expect(applied.items).toHaveLength(WIDGETS.length);
+    expect(applied.hidden).toEqual([WIDGETS[1].id]);
+  });
+
+  it("is a no-op when nothing moved", () => {
+    const start = defaultLayout();
+    expect(applyPositions(start, [])).toEqual(start);
+  });
+});
+
+describe("toggleWidget", () => {
+  it("hides and re-shows without losing position", () => {
+    const start = defaultLayout();
+    const hiddenOnce = toggleWidget(start, WIDGETS[0].id);
+    expect(hiddenOnce.hidden).toEqual([WIDGETS[0].id]);
+    // Position survives being hidden, so re-showing puts it back where it was.
+    expect(hiddenOnce.items).toEqual(start.items);
+    expect(toggleWidget(hiddenOnce, WIDGETS[0].id).hidden).toEqual([]);
+  });
+});
+
+describe("formatBytes", () => {
+  it("scales into IEC units", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1024)).toBe("1.0 KiB");
+    expect(formatBytes(1536)).toBe("1.5 KiB");
+    expect(formatBytes(1024 * 1024)).toBe("1.0 MiB");
+    expect(formatBytes(1024 ** 3 * 7.6)).toBe("7.6 GiB");
+    // Past 10 the decimal is noise on an instantaneous sample.
+    expect(formatBytes(1024 ** 3 * 34)).toBe("34 GiB");
+  });
+
+  it("renders absent values as a dash rather than zero", () => {
+    expect(formatBytes(null)).toBe("-");
+    expect(formatBytes(undefined)).toBe("-");
+    expect(formatBytes(NaN)).toBe("-");
+    expect(formatBytes(-1)).toBe("-");
+  });
+});
+
+describe("formatPercent", () => {
+  it("keeps a multi-core figure above 100", () => {
+    // A container on two cores legitimately reads 200%; clamping would hide
+    // the most interesting row on the page.
+    expect(formatPercent(250)).toBe("250%");
+    expect(formatPercent(0)).toBe("0.0%");
+    expect(formatPercent(7.5)).toBe("7.5%");
+    // Above 10 the decimal is dropped.
+    expect(formatPercent(72.8)).toBe("73%");
+    expect(formatPercent(null)).toBe("-");
+  });
+});
+
+describe("formatAge", () => {
+  it("describes snapshot freshness", () => {
+    const now = Date.parse("2026-08-04T12:00:30Z");
+    expect(formatAge(null, now)).toBe("collecting");
+    expect(formatAge("2026-08-04T12:00:30Z", now)).toBe("just now");
+    expect(formatAge("2026-08-04T12:00:20Z", now)).toBe("10s ago");
+    expect(formatAge("2026-08-04T11:58:30Z", now)).toBe("2m ago");
+    expect(formatAge("2026-08-04T09:00:30Z", now)).toBe("3h ago");
+    expect(formatAge("not a date", now)).toBe("collecting");
+  });
+});

--- a/web/src/lib/dashboardLayout.ts
+++ b/web/src/lib/dashboardLayout.ts
@@ -1,0 +1,176 @@
+import type { DashboardLayout, DashboardLayoutItem } from "./api";
+
+/// The layout shape the backend accepts. Bumped only on a breaking change; a
+/// stored layout at any other version is discarded for the defaults.
+export const LAYOUT_SCHEMA_VERSION = 1;
+/// Grid width every widget position is expressed in.
+export const GRID_COLUMNS = 12;
+/// Below this the grid is too narrow to arrange sensibly, so editing is hidden
+/// rather than letting someone save a layout mangled by a phone viewport.
+export const EDIT_MIN_WIDTH = 768;
+
+export interface WidgetDefinition {
+  id: string;
+  title: string;
+  /// Where this widget sits on a dashboard nobody has customized.
+  default: Omit<DashboardLayoutItem, "id">;
+  minW: number;
+  minH: number;
+}
+
+/// Every widget the dashboard can show, in the order a fresh dashboard stacks
+/// them. Ids are the stored identity, so renaming one drops that widget from
+/// every saved layout; add a new id instead.
+///
+/// Default heights are sized to hold each widget's content at ROW_HEIGHT
+/// without an inner scrollbar, since a card that is born scrolling reads as
+/// broken rather than as resizable.
+export const WIDGETS: WidgetDefinition[] = [
+  {
+    id: "system-usage",
+    title: "System usage",
+    default: { x: 0, y: 0, w: 6, h: 7 },
+    minW: 3,
+    minH: 4,
+  },
+  {
+    id: "fleet-status",
+    title: "Workspace status",
+    default: { x: 6, y: 0, w: 6, h: 7 },
+    minW: 3,
+    minH: 4,
+  },
+  {
+    id: "containers",
+    title: "Containers",
+    default: { x: 0, y: 7, w: 12, h: 6 },
+    minW: 4,
+    minH: 4,
+  },
+  {
+    id: "versions",
+    title: "Versions",
+    default: { x: 0, y: 13, w: 6, h: 4 },
+    minW: 3,
+    minH: 3,
+  },
+  {
+    id: "provisioning",
+    title: "Provisioning",
+    default: { x: 6, y: 13, w: 6, h: 4 },
+    minW: 3,
+    minH: 3,
+  },
+];
+
+export function defaultLayout(): DashboardLayout {
+  return {
+    schema_version: LAYOUT_SCHEMA_VERSION,
+    items: WIDGETS.map((w) => ({ id: w.id, ...w.default })),
+    hidden: [],
+  };
+}
+
+/// Clamp one stored rectangle into the grid.
+///
+/// A saved layout can predate a widget's current minimum size, and nothing
+/// stops a hand-edited row holding absurd coordinates, so geometry is fixed up
+/// here rather than trusted. The backend bounds what it stores; this bounds
+/// what actually gets rendered.
+function clamp(item: DashboardLayoutItem, widget: WidgetDefinition): DashboardLayoutItem {
+  const w = Math.min(GRID_COLUMNS, Math.max(widget.minW, Math.floor(item.w) || widget.default.w));
+  const h = Math.max(widget.minH, Math.floor(item.h) || widget.default.h);
+  const x = Math.min(GRID_COLUMNS - w, Math.max(0, Math.floor(item.x) || 0));
+  const y = Math.max(0, Math.floor(item.y) || 0);
+  return { id: item.id, x, y, w, h };
+}
+
+/// Reconcile a stored layout with the widget catalog this build ships.
+///
+/// Three things drift between a saved layout and the code reading it: a widget
+/// was removed, a widget was added, or the stored payload is junk. All three
+/// have to resolve to something renderable, because the alternative is a
+/// dashboard that cannot load until someone clears a database row.
+export function mergeLayout(stored: DashboardLayout | null): DashboardLayout {
+  if (!stored || stored.schema_version !== LAYOUT_SCHEMA_VERSION || !Array.isArray(stored.items)) {
+    return defaultLayout();
+  }
+
+  const hidden = (Array.isArray(stored.hidden) ? stored.hidden : []).filter((id) => WIDGETS.some((w) => w.id === id));
+
+  // Widgets keep their saved position; ones added in a later release are
+  // appended below everything rather than overlapping what is already placed.
+  let nextY = stored.items.reduce(
+    (max, item) => Math.max(max, (Math.floor(item.y) || 0) + (Math.floor(item.h) || 1)),
+    0,
+  );
+  const items = WIDGETS.map((widget) => {
+    const saved = stored.items.find((item) => item?.id === widget.id);
+    if (!saved) {
+      const appended = { id: widget.id, ...widget.default, y: nextY };
+      nextY += widget.default.h;
+      return appended;
+    }
+    return clamp(saved, widget);
+  });
+
+  return { schema_version: LAYOUT_SCHEMA_VERSION, items, hidden };
+}
+
+/// Fold the grid's reported positions back into a full layout.
+///
+/// The grid only ever reports the widgets it rendered, so a hidden widget is
+/// absent from `positions`. Overwriting `items` with that list wholesale would
+/// throw away where a hidden widget used to sit, which is the position it needs
+/// when it is shown again.
+export function applyPositions(layout: DashboardLayout, positions: DashboardLayoutItem[]): DashboardLayout {
+  const moved = new Map(positions.map((p) => [p.id, p]));
+  return { ...layout, items: layout.items.map((item) => moved.get(item.id) ?? item) };
+}
+
+/// The widgets to render, in layout order, skipping hidden ones.
+export function visibleWidgets(layout: DashboardLayout): WidgetDefinition[] {
+  return WIDGETS.filter((w) => !layout.hidden.includes(w.id));
+}
+
+export function toggleWidget(layout: DashboardLayout, id: string): DashboardLayout {
+  const hidden = layout.hidden.includes(id) ? layout.hidden.filter((h) => h !== id) : [...layout.hidden, id];
+  return { ...layout, hidden };
+}
+
+/// Byte counts as an operator reads them. IEC units, because that is what
+/// container runtimes report and mixing the two on one page invites the reader
+/// to compare figures that are 7% apart for no visible reason.
+export function formatBytes(bytes: number | null | undefined): string {
+  if (bytes === null || bytes === undefined || !Number.isFinite(bytes) || bytes < 0) return "-";
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  const units = ["KiB", "MiB", "GiB", "TiB", "PiB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  // One decimal below 10 keeps "1.5 GiB" readable without implying precision
+  // an instantaneous sample does not have.
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
+export function formatPercent(percent: number | null | undefined): string {
+  if (percent === null || percent === undefined || !Number.isFinite(percent)) return "-";
+  return `${percent < 10 ? percent.toFixed(1) : Math.round(percent)}%`;
+}
+
+/// How long ago the snapshot was taken, for the freshness line. Sampled data is
+/// near-real-time, and saying so is the difference between "the dashboard is
+/// wrong" and "the dashboard is ten seconds behind".
+export function formatAge(sampledAt: string | null, now: number = Date.now()): string {
+  if (!sampledAt) return "collecting";
+  const seconds = Math.round((now - new Date(sampledAt).getTime()) / 1000);
+  if (!Number.isFinite(seconds)) return "collecting";
+  if (seconds < 1) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.round(minutes / 60)}h ago`;
+}


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a `/dashboard` admin page showing CityHall system usage, per-workspace container CPU and memory, workspace status rollups, version spread, and provisioning jobs. Cards are dragged and resized in an explicit Edit mode, and the arrangement is saved per user so it follows an admin to another browser. `/` now redirects there for anyone holding the new `dashboard.read` permission, and to `/users` otherwise.

The load-bearing decision is that the endpoint does no backend I/O. `GET /api/workspaces` already called `docker container inspect` once per user with a workspace row, sequentially, on a page that polls every 10 seconds; a dashboard needing the same data on the same cadence would have multiplied that by every watching admin. Instead a background task samples the fleet on a fixed interval and publishes an immutable snapshot, and a request reads that plus one database query. Fleet status now comes from a single `docker ps`, so a poll costs the same whether there are five workspaces or five hundred. The workspaces list uses the same batch primitive, since it already discarded the address that made the per-user call necessary.

Sources fail independently. A tick that cannot reach the runtime keeps the previous figures and records what broke, because a dashboard that blanks itself when the daemon hiccups is worse than one showing numbers ten seconds old and labelled as such. `sampled_at` is null until the first sample, which reads as "collecting" rather than as an empty fleet.

The system figures are deliberately not called "host". CityHall usually runs in a container beside the workspaces it reports on, so every payload carries the scope it describes, detected by default and overridable with `SYSTEM_METRICS_SCOPE`. A cgroup memory limit is reported as its own block rather than substituted for the system totals, which would have produced system-wide CPU beside container-local memory under one label. Disk is opt-in through `SYSTEM_METRICS_DISK_PATH` and omitted when unset: under an overlay filesystem the obvious default measures CityHall's own image layers instead of workspace storage.

Grid drag and resize uses `react-grid-layout`. Hand-rolling snap-to-grid with collision handling, pointer capture, drag-versus-click suppression, and container-width tracking is a large amount of interaction code to own for an admin page. Its v2 API was verified against this stack rather than assumed: it replaced the `WidthProvider` HOC with a `useContainerWidth` hook, groups props into `gridConfig`/`dragConfig`/`resizeConfig`, and ships its own types, so the deprecated `@types` package is not needed.

Closes #12

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Sign in as an admin. You land on `/dashboard`, and a Dashboard entry appears first in the top bar.
- [ ] Confirm the System usage card shows a CPU percentage, a memory figure, and a scope label reading "CityHall host" when running natively.
- [ ] Start a workspace from the Workspaces page, wait for a poll, and confirm it turns `running` on the dashboard with a live CPU and memory figure that changes between refreshes (docker backend).
- [ ] Watch the freshness line beside the heading count up between polls, and confirm it says "collecting the first sample" for the first few seconds after a restart.
- [ ] Restart CityHall with `SYSTEM_METRICS_DISK_PATH=/` and confirm a Disk row appears; unset it and confirm the row disappears rather than showing a wrong number.
- [ ] Restart with `WORKSPACE_BACKEND=process` and confirm the Containers card says resource usage is unavailable on this backend, with no CPU or Memory columns, instead of showing zeros.
- [ ] Stop the docker daemon, wait a poll, and confirm a warning names the failed source while the last good figures stay on screen rather than the page blanking.
- [ ] Click Edit layout, drag a card by its title, resize it from its corner, click Done, then reload and confirm the arrangement came back.
- [ ] In Edit layout, untick a widget, click Done without dragging anything, then reload and confirm it is still hidden. Tick it again and confirm it returns to where it was.
- [ ] Sign in from a different browser and confirm the same layout is restored.
- [ ] Click Reset layout while editing and confirm the default arrangement returns.
- [ ] Narrow the window below 768px and confirm the Edit layout button disappears rather than offering a grid editor on a viewport too narrow to arrange.
- [ ] As a `member` user, confirm no Dashboard entry appears, `/dashboard` bounces you to `/users`, and `GET /api/dashboard` returns 403.
- [ ] Confirm the Workspaces page still reports the same statuses as before, now from one `docker ps` rather than one inspect per user.

## Checklist

- [x] New and existing tests pass
- [x] `cargo fmt` / `cargo clippy` clean (API changes)
- [x] `npm run lint` / `npm run format:check` clean (web changes)
- [x] Documentation was updated where necessary

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 5, via Claude Code and the `/aoe-implement` skill.

Investigation, plan, and implementation drafted by Claude under my direction. The plan was pressure-tested with the `/debate` skill across three models, which is where the per-request fan-out got caught and replaced with the background sampler; it also killed a cgroup memory override that would have mislabelled container-local memory as host memory, and moved the status rollups server-side. I made the scope calls (drag-resize grid, server-side layout, dashboard as the landing page), reviewed each commit, and ran the manual steps above.

Two defects were found by running the thing rather than by reading it, both fixed with regression tests: the dashboard printed `not_created` beside a running version when a container outlived its intent row, and an edit session that only toggled a widget's visibility saved nothing. A `u32` overflow in the layout bounds check was also caught and fixed before it could panic a request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Dashboard with fleet status, workspace provisioning, system usage, versions, and resource metrics.
  * Added responsive widget layouts with drag, resize, visibility controls, saving, resetting, and automatic refresh.
  * Added persisted, validated dashboard layouts for each account.
  * Added Docker workspace CPU and memory usage reporting.
  * Added dashboard access control and navigation.

* **Bug Fixes**
  * Improved workspace status reporting with batch loading and graceful fallbacks.

* **Documentation**
  * Documented dashboard endpoints, permissions, metrics, configuration, and backend limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->